### PR TITLE
CircleCI updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.4-node-browsers
     steps:
+      - checkout
       - run: npm install
       - run: bundle install
       - run: bundle exec jekyll build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,17 @@
 version: 2
 jobs:
   build:
-    environment:
-      NOKOGIRI_USE_SYSTEM_LIBRARIES: true
-  deploy-job:
+    docker:
+      - image: circleci/ruby:2.4-node-browsers
     steps:
-      - run:
-          name: Install dependencies
-          command: bundle exec jekyll build
-      - run:
-          name: Overrides tests
-          command: echo "Tests disabled"
-      - run:
-          name: Deploy master brnach to AWS
-          command: aws s3 sync ./_site s3://tspdev.gov/ --delete
-
-workflows:
-  version: 2
-  build-deploy:
-    jobs:
-      filters:
-        branches:
-          only: master
+      - run: npm install
+      - run: bundle install
+      - run: bundle exec jekyll build
+      - deploy:
+          name: deploy
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              aws s3 sync ./_site s3://tspdev.gov/test/ --delete
+            else
+              echo "Not master branch, dry run only"
+            fi


### PR DESCRIPTION
Tried to simplify this a bit so it's a bit more flexible and extendable. So when a new commit is added to Github, CircleCI should install the dependencies, build the jekyll site, and then optionally (if it is the `master` branch) deploy it to s3. 

In the future if you wanted to add a test step, it could be added before the deploy step so that way every branch/commit could be checked to make sure all of the tests pass.

While we test this I set it to deploy the site into a `test` subdirectory as to not wipe the whole bucket. Once we have things working the way we want the directory can be removed.