### PR TITLE
Fund comparison tool

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,3 +37,7 @@ exclude:
   - package-lock.json
   - package.json
   - vendor
+
+collections:
+  funds:
+    output: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -113,6 +113,8 @@ fund-options:
         href: /fund-basics/f-fund/
       - text: I Fund
         href: /fund-basics/i-fund/
+      - text: L Fund
+        href: /fund-basics/l-fund/
   - text: Fund performance
     href: /fund-performance/
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -105,6 +105,14 @@ fund-options:
     subnav:
       - text: S Fund
         href: /fund-basics/s-fund/
+      - text: G Fund
+        href: /fund-basics/g-fund/
+      - text: C Fund
+        href: /fund-basics/c-fund/
+      - text: F Fund
+        href: /fund-basics/f-fund/
+      - text: I Fund
+        href: /fund-basics/i-fund/
   - text: Fund performance
     href: /fund-performance/
 

--- a/_funds/C.md
+++ b/_funds/C.md
@@ -58,6 +58,12 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
+risks: |
+  Your investment in the C Fund is subject to [market risk](#) because the prices of the stocks in the S&P 500 Index rise and fall.
+
+  By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
+rewards: |
+  While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
 ---
 
 <li>

--- a/_funds/C.md
+++ b/_funds/C.md
@@ -1,0 +1,86 @@
+---
+permalink: /fund-basics/c-fund/
+layout: fund-details
+title: C fund
+sidenav: fund-options
+Fund_letter: C
+subfund_name:
+Fund_subtitle: Common Stock Index Investment Fund
+Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
+questions:
+  - question: Why should I invest in the S Fund?
+    answer: While investment in the S Fund carries risk, it also offers the opportunity to experience gains from equity ownership of small-to-mid-sized U.S. companies. It provides and excellent means of further diversifying your domestic equity holdings.
+  - question: Am I ok with market and inflation risk?
+    answer: There is a risk of loss if the Dow Jones U.S. Completion TSM Index declines in response to changes in overall economic conditions (market risk) or if the S Fund does not grow enough to offset the reduction in purchasing power (inflation risk).
+  - question: How can I use the S Fund in my TSP?
+    answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
+avg_annual_returns:
+    ytd: +12.89%
+    one_yr: +13.89%
+    three_yr: +14.89%
+    five_yr: +15.89%
+    ten_yr: +16.89%
+    inception:
+summary_details:
+    assets: $67.6 billion
+    admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
+    other_expense: $0.027%
+    benchmark_index: Dow Jones U.S. Completion TSM Index | www.djindexes.com
+    asset_manager: BlackRock Institutional Trust Company, N.A
+top_ten_holdings:
+  - name: Tesla Motors Inc.
+    abbr: TSLA
+  - name: Las Vegas Sands Corp.
+    abbr: LVS
+additional_info: |
+  The S Fund is invested in a separate account
+  that is managed by BlackRock Institutional
+  Trust Company, N.A. The Fund is invested in
+  the Dow Jones U.S. Completion TSM Index,
+  which contains a large number of stocks,
+  including illiquid stocks with low trading
+  volume and stocks with prices lower than
+  $1.00 per share.
+
+  Therefore, it is not efficient for the Fund to
+  invest in every stock in the index. The S Fund
+  holds the stocks of most of the companies in
+  the index with market values greater than $1
+  billion. However, a mathematical sampling
+  technique is used to select among the smaller
+  stocks.
+
+  The performance of the S Fund is evaluated
+  on the basis of how closely its returns match
+  those of the Dow Jones U.S. Completion TSM
+  Index. A portion of S Fund assets is reserved
+  to meet the needs of daily client activity.
+  This liquidity reserve is invested in futures
+  contracts of the S&P 400 and Russell 2000
+  (other broad equity indexes).
+---
+
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">
+  Performance &amp; risks
+</button>
+    <div id="a2" class="usa-accordion-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-one-whole">
+          <h3>Charts and graphs</h3>
+        </div>
+      </div>
+    </div>
+</li>
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a3">
+  Composition
+</button>
+    <div id="a3" class="usa-accordion-content">
+    <div class="usa-grid-full">
+      <div class="usa-width-one-whole">
+        <h3>Charts and graphs 2</h3>
+      </div>
+    </div>
+    </div>
+</li>

--- a/_funds/F.md
+++ b/_funds/F.md
@@ -1,0 +1,86 @@
+---
+permalink: /fund-basics/f-fund/
+layout: fund-details
+title: F fund
+sidenav: fund-options
+Fund_letter: F
+subfund_name:
+Fund_subtitle: Fixed Income Index Investment Fund
+Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
+questions:
+  - question: Why should I invest in the S Fund?
+    answer: While investment in the S Fund carries risk, it also offers the opportunity to experience gains from equity ownership of small-to-mid-sized U.S. companies. It provides and excellent means of further diversifying your domestic equity holdings.
+  - question: Am I ok with market and inflation risk?
+    answer: There is a risk of loss if the Dow Jones U.S. Completion TSM Index declines in response to changes in overall economic conditions (market risk) or if the S Fund does not grow enough to offset the reduction in purchasing power (inflation risk).
+  - question: How can I use the S Fund in my TSP?
+    answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
+avg_annual_returns:
+    ytd: 12.89%
+    one_yr: 13.89%
+    three_yr: 14.89%
+    five_yr: 15.89%
+    ten_yr: 16.89%
+    inception:
+summary_details:
+    assets: $67.6 billion
+    admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
+    other_expense: $0.027%
+    benchmark_index: Dow Jones U.S. Completion TSM Index | www.djindexes.com
+    asset_manager: BlackRock Institutional Trust Company, N.A
+top_ten_holdings:
+  - name: Tesla Motors Inc.
+    abbr: TSLA
+  - name: Las Vegas Sands Corp.
+    abbr: LVS
+additional_info: |
+  The S Fund is invested in a separate account
+  that is managed by BlackRock Institutional
+  Trust Company, N.A. The Fund is invested in
+  the Dow Jones U.S. Completion TSM Index,
+  which contains a large number of stocks,
+  including illiquid stocks with low trading
+  volume and stocks with prices lower than
+  $1.00 per share.
+
+  Therefore, it is not efficient for the Fund to
+  invest in every stock in the index. The S Fund
+  holds the stocks of most of the companies in
+  the index with market values greater than $1
+  billion. However, a mathematical sampling
+  technique is used to select among the smaller
+  stocks.
+
+  The performance of the S Fund is evaluated
+  on the basis of how closely its returns match
+  those of the Dow Jones U.S. Completion TSM
+  Index. A portion of S Fund assets is reserved
+  to meet the needs of daily client activity.
+  This liquidity reserve is invested in futures
+  contracts of the S&P 400 and Russell 2000
+  (other broad equity indexes).
+---
+
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">
+  Performance &amp; risks
+</button>
+    <div id="a2" class="usa-accordion-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-one-whole">
+          <h3>Charts and graphs</h3>
+        </div>
+      </div>
+    </div>
+</li>
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a3">
+  Composition
+</button>
+    <div id="a3" class="usa-accordion-content">
+    <div class="usa-grid-full">
+      <div class="usa-width-one-whole">
+        <h3>Charts and graphs 2</h3>
+      </div>
+    </div>
+    </div>
+</li>

--- a/_funds/F.md
+++ b/_funds/F.md
@@ -58,6 +58,12 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
+risks: |
+  Your investment in the C Fund is subject to [market risk](#) because the prices of the stocks in the S&P 500 Index rise and fall.
+
+  By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
+rewards: |
+  While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
 ---
 
 <li>

--- a/_funds/F.md
+++ b/_funds/F.md
@@ -4,6 +4,7 @@ layout: fund-details
 title: F fund
 sidenav: fund-options
 Fund_letter: F
+Fund_order: 2
 subfund_name:
 Fund_subtitle: Fixed Income Index Investment Fund
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.

--- a/_funds/G.md
+++ b/_funds/G.md
@@ -58,6 +58,12 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
+risks: |
+  Your investment in the C Fund is subject to [market risk](#) because the prices of the stocks in the S&P 500 Index rise and fall.
+
+  By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
+rewards: |
+  While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
 ---
 
 <li>

--- a/_funds/G.md
+++ b/_funds/G.md
@@ -4,6 +4,7 @@ layout: fund-details
 title: G fund
 sidenav: fund-options
 Fund_letter: G
+Fund_order: 1
 subfund_name:
 Fund_subtitle: Government Securities Investment Fund
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
@@ -15,11 +16,11 @@ questions:
   - question: How can I use the S Fund in my TSP?
     answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
 avg_annual_returns:
-    ytd: +12.89%
-    one_yr: +13.89%
-    three_yr: +14.89%
-    five_yr: +15.89%
-    ten_yr: +16.89%
+    ytd: 12.89%
+    one_yr: 13.89%
+    three_yr: 14.89%
+    five_yr: 15.89%
+    ten_yr: 16.89%
     inception:
 summary_details:
     assets: $67.6 billion

--- a/_funds/G.md
+++ b/_funds/G.md
@@ -1,13 +1,11 @@
 ---
+permalink: /fund-basics/g-fund/
 layout: fund-details
-title: S Fund
-styles:
+title: G fund
 sidenav: fund-options
-scripts:
-permalink: /fund-basics/s-fund/
-Fund_name: S Fund
-Fund_subtitle_line_1: Small cap stock
-Fund_subtitle_line_2: Index investment fund
+Fund_letter: G
+subfund_name:
+Fund_subtitle: Government Securities Investment Fund
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
 questions:
   - question: Why should I invest in the S Fund?
@@ -22,6 +20,7 @@ avg_annual_returns:
     three_yr: +14.89%
     five_yr: +15.89%
     ten_yr: +16.89%
+    inception:
 summary_details:
     assets: $67.6 billion
     admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
@@ -59,9 +58,7 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
-
 ---
-
 
 <li>
     <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">

--- a/_funds/I.md
+++ b/_funds/I.md
@@ -1,0 +1,61 @@
+---
+permalink: /fund-basics/i-fund/
+layout: fund-details
+title: I fund
+sidenav: fund-options
+Fund_letter: I
+subfund_name:
+Fund_subtitle: International Stock Index Investment Fund
+Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
+questions:
+  - question: Why should I invest in the S Fund?
+    answer: While investment in the S Fund carries risk, it also offers the opportunity to experience gains from equity ownership of small-to-mid-sized U.S. companies. It provides and excellent means of further diversifying your domestic equity holdings.
+  - question: Am I ok with market and inflation risk?
+    answer: There is a risk of loss if the Dow Jones U.S. Completion TSM Index declines in response to changes in overall economic conditions (market risk) or if the S Fund does not grow enough to offset the reduction in purchasing power (inflation risk).
+  - question: How can I use the S Fund in my TSP?
+    answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
+avg_annual_returns:
+    ytd: +12.89%
+    one_yr: +13.89%
+    three_yr: +14.89%
+    five_yr: +15.89%
+    ten_yr: +16.89%
+    inception:
+summary_details:
+    assets: $67.6 billion
+    admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
+    other_expense: $0.027%
+    benchmark_index: Dow Jones U.S. Completion TSM Index | www.djindexes.com
+    asset_manager: BlackRock Institutional Trust Company, N.A
+top_ten_holdings:
+  - name: Tesla Motors Inc.
+    abbr: TSLA
+  - name: Las Vegas Sands Corp.
+    abbr: LVS
+additional_info: |
+  The S Fund is invested in a separate account
+  that is managed by BlackRock Institutional
+  Trust Company, N.A. The Fund is invested in
+  the Dow Jones U.S. Completion TSM Index,
+  which contains a large number of stocks,
+  including illiquid stocks with low trading
+  volume and stocks with prices lower than
+  $1.00 per share.
+
+  Therefore, it is not efficient for the Fund to
+  invest in every stock in the index. The S Fund
+  holds the stocks of most of the companies in
+  the index with market values greater than $1
+  billion. However, a mathematical sampling
+  technique is used to select among the smaller
+  stocks.
+
+  The performance of the S Fund is evaluated
+  on the basis of how closely its returns match
+  those of the Dow Jones U.S. Completion TSM
+  Index. A portion of S Fund assets is reserved
+  to meet the needs of daily client activity.
+  This liquidity reserve is invested in futures
+  contracts of the S&P 400 and Russell 2000
+  (other broad equity indexes).
+---

--- a/_funds/I.md
+++ b/_funds/I.md
@@ -58,4 +58,34 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
+risks: |
+  Your investment in the C Fund is subject to [market risk](#) because the prices of the stocks in the S&P 500 Index rise and fall.
+
+  By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
+rewards: |
+  While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
 ---
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">
+  Performance &amp; risks
+</button>
+    <div id="a2" class="usa-accordion-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-one-whole">
+          <h3>Charts and graphs</h3>
+        </div>
+      </div>
+    </div>
+</li>
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a3">
+  Composition
+</button>
+    <div id="a3" class="usa-accordion-content">
+    <div class="usa-grid-full">
+      <div class="usa-width-one-whole">
+        <h3>Charts and graphs 2</h3>
+      </div>
+    </div>
+    </div>
+</li>

--- a/_funds/I.md
+++ b/_funds/I.md
@@ -4,6 +4,7 @@ layout: fund-details
 title: I fund
 sidenav: fund-options
 Fund_letter: I
+Fund_order: 5
 subfund_name:
 Fund_subtitle: International Stock Index Investment Fund
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
@@ -15,11 +16,11 @@ questions:
   - question: How can I use the S Fund in my TSP?
     answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
 avg_annual_returns:
-    ytd: +12.89%
-    one_yr: +13.89%
-    three_yr: +14.89%
-    five_yr: +15.89%
-    ten_yr: +16.89%
+    ytd: 12.89%
+    one_yr: 13.89%
+    three_yr: 14.89%
+    five_yr: 15.89%
+    ten_yr: 16.89%
     inception:
 summary_details:
     assets: $67.6 billion

--- a/_funds/L.md
+++ b/_funds/L.md
@@ -1,12 +1,12 @@
 ---
-permalink: /fund-basics/c-fund/
+permalink: /fund-basics/l-fund/
 layout: fund-details
-title: C fund
+title: L fund
 sidenav: fund-options
-Fund_letter: C
-Fund_order: 3
+Fund_letter: L
+Fund_order: 6
 subfund_name:
-Fund_subtitle: Common Stock Index Investment Fund
+Fund_subtitle: Lifecycle funds
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
 questions:
   - question: Why should I invest in the S Fund?
@@ -21,7 +21,7 @@ avg_annual_returns:
     three_yr: 14.89%
     five_yr: 15.89%
     ten_yr: 16.89%
-    inception:
+    inception: 5.09%
 summary_details:
     assets: $67.6 billion
     admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
@@ -65,6 +65,7 @@ risks: |
   By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
 rewards: |
   While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
+
 ---
 
 <li>

--- a/_funds/S.md
+++ b/_funds/S.md
@@ -1,0 +1,86 @@
+---
+permalink: /fund-basics/s-fund/
+layout: fund-details
+title: S fund
+sidenav: fund-options
+Fund_letter: S
+subfund_name:
+Fund_subtitle: Small cap stock Index investment fund
+Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.
+questions:
+  - question: Why should I invest in the S Fund?
+    answer: While investment in the S Fund carries risk, it also offers the opportunity to experience gains from equity ownership of small-to-mid-sized U.S. companies. It provides and excellent means of further diversifying your domestic equity holdings.
+  - question: Am I ok with market and inflation risk?
+    answer: There is a risk of loss if the Dow Jones U.S. Completion TSM Index declines in response to changes in overall economic conditions (market risk) or if the S Fund does not grow enough to offset the reduction in purchasing power (inflation risk).
+  - question: How can I use the S Fund in my TSP?
+    answer: The S Fund can be useful in a portfolio that also contains stock funds that track other indexes. The C, S, and I Funds, for example, track different segments of the overall stock market without overlapping. By investing in all segments of the stock market (as opposed to just one), you reduce your exposure to market risk.
+avg_annual_returns:
+    ytd: 12.89%
+    one_yr: 13.89%
+    three_yr: 14.89%
+    five_yr: 15.89%
+    ten_yr: 16.89%
+    inception: 5.09%
+summary_details:
+    assets: $67.6 billion
+    admin_expense: $0.032/$1,000 account balance. 0.032% (3.2 basis points)
+    other_expense: $0.027%
+    benchmark_index: Dow Jones U.S. Completion TSM Index | www.djindexes.com
+    asset_manager: BlackRock Institutional Trust Company, N.A
+top_ten_holdings:
+  - name: Tesla Motors Inc.
+    abbr: TSLA
+  - name: Las Vegas Sands Corp.
+    abbr: LVS
+additional_info: |
+  The S Fund is invested in a separate account
+  that is managed by BlackRock Institutional
+  Trust Company, N.A. The Fund is invested in
+  the Dow Jones U.S. Completion TSM Index,
+  which contains a large number of stocks,
+  including illiquid stocks with low trading
+  volume and stocks with prices lower than
+  $1.00 per share.
+
+  Therefore, it is not efficient for the Fund to
+  invest in every stock in the index. The S Fund
+  holds the stocks of most of the companies in
+  the index with market values greater than $1
+  billion. However, a mathematical sampling
+  technique is used to select among the smaller
+  stocks.
+
+  The performance of the S Fund is evaluated
+  on the basis of how closely its returns match
+  those of the Dow Jones U.S. Completion TSM
+  Index. A portion of S Fund assets is reserved
+  to meet the needs of daily client activity.
+  This liquidity reserve is invested in futures
+  contracts of the S&P 400 and Russell 2000
+  (other broad equity indexes).
+---
+
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">
+  Performance &amp; risks
+</button>
+    <div id="a2" class="usa-accordion-content">
+      <div class="usa-grid-full">
+        <div class="usa-width-one-whole">
+          <h3>Charts and graphs</h3>
+        </div>
+      </div>
+    </div>
+</li>
+<li>
+    <button class="usa-accordion-button" aria-expanded="false" aria-controls="a3">
+  Composition
+</button>
+    <div id="a3" class="usa-accordion-content">
+    <div class="usa-grid-full">
+      <div class="usa-width-one-whole">
+        <h3>Charts and graphs 2</h3>
+      </div>
+    </div>
+    </div>
+</li>

--- a/_funds/S.md
+++ b/_funds/S.md
@@ -58,6 +58,13 @@ additional_info: |
   This liquidity reserve is invested in futures
   contracts of the S&P 400 and Russell 2000
   (other broad equity indexes).
+risks: |
+  Your investment in the C Fund is subject to [market risk](#) because the prices of the stocks in the S&P 500 Index rise and fall.
+
+  By investing in the C Fund, you are also exposed to [inflation risk](#), meaning your C Fund investment may not grow enough to offset inflation.
+rewards: |
+  While investment in the C Fund carries risk, it also offers the opportunity to experience gains from equity ownership of large and mid-sized U.S. company stocks.
+
 ---
 
 <li>

--- a/_funds/S.md
+++ b/_funds/S.md
@@ -4,6 +4,7 @@ layout: fund-details
 title: S fund
 sidenav: fund-options
 Fund_letter: S
+Fund_order: 4
 subfund_name:
 Fund_subtitle: Small cap stock Index investment fund
 Fund_objective: The S Fund's investment objective is to match the performance of the Dow Jones U.S. Completion Total Stock Market Index, a broad market index made up of stocks of small-to-medium U.S. companies not included in the S&P 500 Index.

--- a/_includes/components/fund-comparison.html
+++ b/_includes/components/fund-comparison.html
@@ -1,0 +1,145 @@
+<div class="fund-comparison-tool">
+<h2>Let’s decide on a simple investor profile. If you know already, skip this step</h2>
+<form>
+  <p> I consider myself risk <label class="usa-sr-only" for="options">Risk type</label>
+  <select name="options" id="options">
+    <option value>- Select -</option>
+    <option value="value1">Option A</option>
+    <option value="value2">Option B</option>
+    <option value="value3">Option C</option>
+  </select> and I expect to retire in <label class="usa-sr-only" for="options">Years</label>
+  <select name="options" id="options">
+    <option value>- Select -</option>
+    <option value="value1">Option A</option>
+    <option value="value2">Option B</option>
+    <option value="value3">Option C</option>
+  </select>
+years.
+ I'm happy with <label class="usa-sr-only" for="options">type of returns</label>
+  <select name="options" id="options">
+    <option value>- Select -</option>
+    <option value="value1">Option A</option>
+    <option value="value2">Option B</option>
+    <option value="value3">Option C</option>
+  </select>
+returns.
+  </p>
+</form>
+
+<div class="usa-alert usa-alert-info">
+  <div class="usa-alert-body">
+<p class="usa-alert-text">You are a _______________ investor, and the best funds for your investment profile are highlighted below. Let's take a look.</p>
+</div>
+</div>
+
+
+<ul class="usa-accordion usa-tabs">
+  <li>
+    <button class="usa-accordion-button"
+      aria-expanded="true"
+      aria-controls="a1">
+      ROR (YTD)
+    </button>
+    <div id="a1" class="usa-accordion-content">
+      <div class="flex-container" id="fund-listing">
+      {% for fund in site.funds %}
+      <input type="checkbox" id="show-{{ fund.Fund_letter | downcase }}-fund" />
+      <label for="show-{{ fund.Fund_letter | downcase }}-fund">
+      <div class="flex-item fund-item fund-item-inactive visible" id="{{ fund.Fund_letter }}-fund">
+      <div class="fund-header">
+      <span>{{ fund.Fund_letter }}</span>
+      {{ fund.Fund_subtitle }}
+        </div>
+        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
+        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
+        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
+        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
+        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+      </div>
+      </label>
+        {% endfor %}
+      </div>
+    </div>
+  </li><li>
+    <button class="usa-accordion-button"
+      aria-expanded="false"
+      aria-controls="a2">
+      Summary
+    </button>
+    <div id="a2" class="usa-accordion-content">
+      <div class="flex-container" id="fund-listing">
+      {% for fund in site.funds %}
+      <input type="checkbox" id="show-{{ fund.Fund_letter | downcase }}-fund" />
+      <label for="show-{{ fund.Fund_letter | downcase }}-fund">
+      <div class="flex-item fund-item fund-item-inactive visible" id="{{ fund.Fund_letter }}-fund">
+      <div class="fund-header">
+      <span>{{ fund.Fund_letter }}</span>
+      {{ fund.Fund_subtitle }}
+        </div>
+        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
+        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
+        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
+        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
+        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+      </div>
+      </label>
+        {% endfor %}
+      </div>
+    </div>
+  </li><li>
+    <button class="usa-accordion-button"
+      aria-expanded="false"
+      aria-controls="a3">
+      Risks
+    </button>
+    <div id="a3" class="usa-accordion-content">
+      <div class="flex-container" id="fund-listing">
+      {% for fund in site.funds %}
+      <input type="checkbox" id="show-{{ fund.Fund_letter | downcase }}-fund" />
+      <label for="show-{{ fund.Fund_letter | downcase }}-fund">
+      <div class="flex-item fund-item fund-item-inactive visible" id="{{ fund.Fund_letter }}-fund">
+      <div class="fund-header">
+      <span>{{ fund.Fund_letter }}</span>
+      {{ fund.Fund_subtitle }}
+        </div>
+        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
+        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
+        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
+        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
+        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+      </div>
+      </label>
+        {% endfor %}
+      </div>
+    </div>
+  </li><li>
+    <button class="usa-accordion-button"
+      aria-expanded="false"
+      aria-controls="a4">
+      Rewards
+    </button>
+    <div id="a4" class="usa-accordion-content">
+      <div class="flex-container" id="fund-listing">
+      {% for fund in site.funds %}
+      <input type="checkbox" id="show-{{ fund.Fund_letter | downcase }}-fund" />
+      <label for="show-{{ fund.Fund_letter | downcase }}-fund">
+      <div class="flex-item fund-item fund-item-inactive visible" id="{{ fund.Fund_letter }}-fund">
+      <div class="fund-header">
+      <span>{{ fund.Fund_letter }}</span>
+      {{ fund.Fund_subtitle }}
+        </div>
+        <div class="fund-content">
+        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
+        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
+        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
+        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
+        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+        </div>
+      </div>
+      </label>
+        {% endfor %}
+      </div>
+    </div>
+  </li>
+</ul>
+</div>

--- a/_includes/components/fund-comparison.html
+++ b/_includes/components/fund-comparison.html
@@ -50,12 +50,14 @@ returns.
       <span>{{ fund.Fund_letter }}</span>
       {{ fund.Fund_subtitle }}
         </div>
+          <div class="fund-content">
         <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
         <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
         <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
         <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
         <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
       </div>
+    </div>
       </label>
         {% endfor %}
       </div>
@@ -76,12 +78,26 @@ returns.
       <span>{{ fund.Fund_letter }}</span>
       {{ fund.Fund_subtitle }}
         </div>
-        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
-        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
-        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
-        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
-        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+          <div class="fund-content">
+            <div class="fund-summary-details">
+                <p><b>Assets</b><br>
+                {{ fund.summary_details.assets }}
+              </p>
+              <p><b>Net admin expense</b><br>
+                {{ fund.summary_details.admin_expense }}
+              </p>
+              <p><b>Other expense</b><br>
+                {{ fund.summary_details.other_expense }}
+              </p>
+                <p><b>Benchmark index</b><br>
+                  {{ fund.summary_details.benchmark_index }}
+                </p>
+                <p><b>Asset manager</b><br>
+                {{ fund.summary_details.asset_manager }}
+              </p>
+            </div>
       </div>
+    </div>
       </label>
         {% endfor %}
       </div>
@@ -102,12 +118,10 @@ returns.
       <span>{{ fund.Fund_letter }}</span>
       {{ fund.Fund_subtitle }}
         </div>
-        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
-        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
-        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
-        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
-        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+        <div class="fund-content">
+        <p>{{ fund.risks | markdownify }}</p>
       </div>
+    </div>
       </label>
         {% endfor %}
       </div>
@@ -129,11 +143,7 @@ returns.
       {{ fund.Fund_subtitle }}
         </div>
         <div class="fund-content">
-        <p>1-Yr <b>{{ fund.avg_annual_returns.one_yr }}</b></p>
-        <p>3-Yrs <b>{{ fund.avg_annual_returns.three_yr }}</b></p>
-        <p>5-Yrs <b>{{ fund.avg_annual_returns.five_yr }}</b></p>
-        <p>10-Yrs <b>{{ fund.avg_annual_returns.ten_yr }}</b></p>
-        <p>Inception <b>{{ fund.avg_annual_returns.inception }}</b></p>
+        <p>{{ fund.rewards | markdownify }}</p>
         </div>
       </div>
       </label>

--- a/_layouts/fund-details.html
+++ b/_layouts/fund-details.html
@@ -11,11 +11,10 @@ main:
 
 <div class="usa-width-three-fourths usa-layout-docs-main_content">
 <div class="fund-details-header usa-grid-full">
-  <h1>{{ page.Fund_name }}</h1>
-  <a href="#" class="usa-button compare-funds-button">Compare funds</a>
+  <h1>{{ page.Fund_letter }}</h1>
+  <a href="/fund-basics/fund-comparison/" class="usa-button compare-funds-button">Compare funds</a>
   <p>
-    {{page.Fund_subtitle_line_1}}<br>
-    {{page.Fund_subtitle_line_2}}
+    {{page.Fund_subtitle}}
   </p>
 </div>
 <div class="usa-section fund-questions">
@@ -109,7 +108,7 @@ main:
           </div>
         </div>
     </li>
-  {{ content }}
+  {{ page.content }}
     <li>
         <button class="usa-accordion-button" aria-expanded="false" aria-controls="a4">
       Fees &amp; more info

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -13,3 +13,4 @@
 @import 'section-yes-no';
 @import 'fund-details';
 @import 'buttons';
+@import 'fund-comparison-tool.scss';

--- a/_sass/components/_fund-comparison-tool.scss
+++ b/_sass/components/_fund-comparison-tool.scss
@@ -35,7 +35,8 @@
 #show-s-fund:checked,
 #show-i-fund:checked,
 #show-f-fund:checked,
-#show-g-fund:checked
+#show-g-fund:checked,
+#show-l-fund:checked
  {
  + label {
    .fund-item {

--- a/_sass/components/_fund-comparison-tool.scss
+++ b/_sass/components/_fund-comparison-tool.scss
@@ -1,0 +1,48 @@
+.fund-comparison-tool {
+  select {
+    display:inline-block;
+    width: auto;
+    padding-right: 4rem;
+  }
+  .flex-container {
+    display: flex;
+  }
+  .fund-item {
+    color: #666;
+  }
+  .fund-header {
+    text-align: center;
+    color: #fff;
+    background-color: #666;
+    padding: 1rem;
+    span {font-size: 8rem;font-weight:800;
+    display:block;
+    }
+    &:hover {
+      background-color: #323a45;
+    }
+  }
+.fund-content {
+  padding: 1rem;
+}
+}
+
+
+
+#show-c-fund:checked,
+#show-s-fund:checked,
+#show-i-fund:checked,
+#show-f-fund:checked,
+#show-g-fund:checked
+ {
+ + label {
+   .fund-item {
+  color: $color-base;
+  background-color: #fff;
+}
+.fund-header {
+  color: #fff;
+  background-color: #323a45;
+}
+}
+}

--- a/_sass/components/_fund-comparison-tool.scss
+++ b/_sass/components/_fund-comparison-tool.scss
@@ -15,6 +15,7 @@
     color: #fff;
     background-color: #666;
     padding: 1rem;
+    font-size: 1.3rem;
     span {font-size: 8rem;font-weight:800;
     display:block;
     }
@@ -24,6 +25,7 @@
   }
 .fund-content {
   padding: 1rem;
+  font-size: 1.3rem;
 }
 }
 

--- a/pages/fund-basics/fund-comparison.md
+++ b/pages/fund-basics/fund-comparison.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Fund comparison
+styles: 
+sidenav: fund-options
+scripts:
+permalink: /fund-basics/fund-comparison/
+---
+
+# TSP Funds Made Easy
+
+The TSP has a selection of individual and lifecycle funds that offer broad market diversification. You can choose to have your retirement dollars invested in everything from a short-term U.S. Treasury security to index funds comprised of domestic and
+international stocks.
+
+{% include components/fund-comparison.html %}


### PR DESCRIPTION
This PR sets up a new folder `_funds` for all the fund information. 
This will allow for a single source to be updated and then pushed out across the website.

For example Fund information is used on on the fund comparison tool as well as the fund details views.

Screenshot
---

I've got the basics set up, I just need to figure out the best way to build the interaction

![localhost_4000_fund-basics_fund-comparison_](https://user-images.githubusercontent.com/1449852/43976471-ae076c30-9cae-11e8-891d-0f4cdce84c71.png)
