### PR TITLE
Adding contribution limits + fix for top nav links

### DIFF
--- a/_data/theme.yml
+++ b/_data/theme.yml
@@ -44,14 +44,14 @@ colors:
 
 # Top navigation colors
   top-navigation:
-  #   top-nav-bg: '#fff'
+    # top-nav-bg: '#fff'
     top-nav-link: '#5B616E'
-  #   top-nav-link-hover: '#5B616E'
+    top-nav-link-hover: '#5B616E'
     top-nav-link-active: '#fff'
-  #   top-nav-link-hover-bg: '#fff'
-  #   top-nav-link-current: '#fff'
+    # top-nav-link-hover-bg: '#fff'
+    # top-nav-link-current: '#fff'
     top-nav-dropdown-bg: '#323a45'
-  #   top-nav-dropdown-link: '#fff'
+    # top-nav-dropdown-link: '#fff'
     top-nav-dropdown-link-hover-bg: '#323a45'
 
 # Side navigation colors

--- a/_sass/components/_all.scss
+++ b/_sass/components/_all.scss
@@ -13,4 +13,5 @@
 @import 'section-yes-no';
 @import 'fund-details';
 @import 'buttons';
-@import 'fund-comparison-tool.scss';
+@import 'fund-comparison-tool';
+@import 'contribution-limits'

--- a/_sass/components/_contribution-limits.scss
+++ b/_sass/components/_contribution-limits.scss
@@ -1,0 +1,38 @@
+.contribution-limits.usa-tabs {
+
+  .usa-accordion-button {
+    text-align: center;
+    font-size: 2rem;
+    width: 20rem;
+    border: 1px solid #333;
+    margin-bottom: 1rem;
+    span {
+      display:block;
+      margin-bottom: 1rem;
+      font-size: 3rem;
+    }
+    &[aria-expanded="true"]:after {
+      content: none;
+    }
+  }
+
+  th {font-weight: 700;
+    width: 20rem;
+    padding-left: 2rem;
+    vertical-align: text-top;
+  }
+  td {
+    > :first-child {
+      margin-top: 0;
+    }
+    h2:first-child {
+      background-image: url('/assets/img/icons/check-circle-green.svg');
+      background-repeat: no-repeat;
+      padding-left: 3rem;
+      background-position: left center;
+    }
+  }
+  .usa-accordion-content {
+    margin-bottom: 3rem;
+  }
+}

--- a/_sass/components/_top-nav.scss
+++ b/_sass/components/_top-nav.scss
@@ -22,11 +22,14 @@
           color: $top-nav-link;
         }
       }
-      &[aria-expanded=true] span {
+      &[aria-expanded=true] {
+        span,
+        &:hover span {
         @if variable-exists(top-nav-link-active) {
           color: $top-nav-link-active;
         }
       }
+    }
       &:hover {
         @if variable-exists(top-nav-link-hover) {
           color: $top-nav-link-hover;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -43,6 +43,7 @@ $image-path: '../uswds/img';
 {% if site.data.theme.colors.top-navigation.top-nav-link-hover %}$top-nav-link-hover: {{ site.data.theme.colors.top-navigation.top-nav-link-hover }};{% endif %}
 {% if site.data.theme.colors.top-navigation.top-nav-link-hover-bg %}$top-nav-link-hover-bg: {{ site.data.theme.colors.top-navigation.top-nav-link-hover-bg }};{% endif %}
 {% if site.data.theme.colors.top-navigation.top-nav-link-current %}$top-nav-link-current: {{ site.data.theme.colors.top-navigation.top-nav-link-current }};{% endif %}
+{% if site.data.theme.colors.top-navigation.top-nav-link-active %}$top-nav-link-active: {{ site.data.theme.colors.top-navigation.top-nav-link-active }};{% endif %}
 {% if site.data.theme.colors.top-navigation.top-nav-dropdown-bg %}$top-nav-dropdown-bg: {{ site.data.theme.colors.top-navigation.top-nav-dropdown-bg }};{% endif %}
 {% if site.data.theme.colors.top-navigation.top-nav-dropdown-link %}$top-nav-dropdown-link: {{ site.data.theme.colors.top-navigation.top-nav-dropdown-link }};{% endif %}
 {% if site.data.theme.colors.top-navigation.top-nav-dropdown-link-hover-bg %}$top-nav-dropdown-link-hover-bg: {{ site.data.theme.colors.top-navigation.top-nav-dropdown-link-hover-bg }};{% endif %}

--- a/assets/img/icons/alert-circle-red.svg
+++ b/assets/img/icons/alert-circle-red.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#e31c3d" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="feather feather-alert-circle"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12" y2="16"></line></svg>

--- a/assets/img/icons/check-circle-green.svg
+++ b/assets/img/icons/check-circle-green.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#2e8540" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="feather feather-check-circle"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>

--- a/assets/img/icons/check-circle.svg
+++ b/assets/img/icons/check-circle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-check-circle"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>

--- a/pages/making-contributions/contribution-limits.md
+++ b/pages/making-contributions/contribution-limits.md
@@ -7,40 +7,160 @@ scripts:
 permalink: /making-contributions/contribution-limits/
 ---
 
-# Contribution limits
+# Know your limits
 
-The Internal Revenue Code (IRC) places limits on the dollar amount of contributions you can make to the TSP. The Internal Revenue Service (IRS) calculates them every year and they can change annually. We announce the limits here and the ThriftLine, and on our [Facebook](https://fb.com/tsp4gov){:target="\_blank"} and [Twitter](https://twitter.com/tsp4gov){:target="\_blank"} pages.
+Here at the TSP, we like to keep our participants informed, so we’ve done a little
+work for you. The 2018 Contributions Limits are below, along with additional
+information to help you make informed decisions.
 
-<table>
-  <caption>Contribution Limits for 2018</caption>
-    <tbody>
-      <tr>
-        <th scope="row">Elective Deferral Limit</th>
-        <td>$18,500</td>
-        <td>IRC §402(g)</td>
-        <td><p>Applies to combined total of traditional and Roth contributions but does not apply to automatic or matching contributions from your agency or service.</p>
-        </td>
-      </tr>
-      <tr>
-        <th scope="row">Annual Addition Limit</th>
-        <td>$55,000</td>
-        <td>IRC §415(c)</td>
-        <td><p>An additional limit imposed on the total amount of all contributions made on behalf of an employee in a calendar year. <span>This limit is per employer and includes employee contributions</span>&nbsp;(tax-deferred, after-tax, and <a class="glossaryTerm" href="../../sitehelp/glossary/glossary.html?term=TaxExemptContributions" title="Glossary term will open in a new window.">tax-exempt</a>), Agency/Service Automatic (1%) Contributions, and <a class="glossaryTerm" href="../../sitehelp/glossary/glossary.html?term=MatchingContributions" title="Glossary term will open in a new window.">Matching Contributions</a>.&nbsp;<span>For 415(c) purposes, working for multiple Federal agencies or services in the same year is considered having one employer.</span></p></td>
-      </tr>
-      <tr>
-        <th scope="row">Catch-up Contribution Limit</th>
-        <td>$6,000</td>
-        <td>IRC §414(v)</td>
-        <td>The maximum amount of <a class="glossaryTerm" href="../../sitehelp/glossary/glossary.html?term=CatchUpContributions" title="Glossary term will open in a new window.">catch-up contributions</a> that can be contributed in a given year by participants age 50 and older. It is separate from the elective deferral and annual addition limit imposed on regular employee contributions.</td>
-      </tr>
-    </tbody>
-</table>
+<ul class="usa-accordion usa-tabs contribution-limits">
+  <li>
+    <button class="usa-accordion-button"
+      aria-expanded="true"
+      aria-controls="a1">
+      <span>$6,000</span>
+      Catch-up<br>contributions
+    </button>
+    <div id="a1" class="usa-accordion-content">
+    <table class="usa-table-borderless">
+        <tbody>
+          <tr>
+            <th scope="row">What’s this?</th>
+            <td markdown="1">
+## Age 50 and over
+This year, on top of the $18,500 regular limit to a retirement plan,
+like the Thri Savings Plan, participants **50 and older can add
+$6000 per year** in catch-up contributions.
+</td>
+          </tr>
+          <tr>
+            <th scope="row">Why it matters?</th>
+            <td markdown="1">
+The additional savings could amount to an **additional $1,000
+per month once you’ve entered retirement.** Contributions are
+also tax-free, but keep in mind that withdrawals are taxed as
+income in retirement.
+<div class="usa-alert usa-alert-info">
+<div class="usa-alert-body">
+Catch-up contributions can be made any time during
+the <b>year in which you turn 55</b>.
+</div>
+</div>
+</td>
+          </tr>
+          <tr>
+            <th scope="row">Here’s what you
+should do now.</th>
+            <td markdown="1">
+**Consider adding that addition $6,000 to your Thrift Savings
+Plan** to help reach your retirement savings goals.
 
-## Uniformed services members:
-* Roth contributions are subject to the elective deferral limit ($18,500 for 2018) even if you make them from tax-exempt pay.
-* You will have to elect traditional contributions for any amount over the elective deferral limit in order to contribute tax-exempt pay toward the annual additions limit.
-* If you are eligible to make catch-up contributions and you are deployed to a designated combat zone, you will not be able to make any traditional catch-up contributions from your tax-exempt pay. However, you will be able to make Roth catch-up contributions from tax-exempt pay.
+You’ll thank yourself later.
 
-## Ready Reserve members:
-* If you are contributing to both a uniformed services and a civilian TSP account, the elective deferral and catch-up contribution limits apply to the total amount of tax-deferred employee contributions you make in a calendar year to both accounts.
-* If you are called to active duty and make tax-exempt contributions while deployed in a combat zone, the amount of employee and agency contributions to your civilian account as well as the tax-exempt contributions you make to your uniformed services account cannot exceed the annual addition limit.
+</td>
+          </tr>
+        </tbody>
+    </table>
+    </div>
+  </li><li>
+    <button class="usa-accordion-button"
+      aria-expanded="false"
+      aria-controls="a2">
+      <span>$18,500</span>
+      Annual<br>Elective Deferral
+    </button>
+    <div id="a2" class="usa-accordion-content">
+    <table class="usa-table-borderless">
+        <tbody>
+          <tr>
+            <th scope="row">What’s this?</th>
+            <td markdown="1">
+## Age 49 and under
+The IRS has announced the **2018 contribution limits** for
+retirement savings accounts, including contribution limits for
+401(k), 403(b), and most 457 plans, as well as income limits for
+IRA contribution deductibility.
+</td>
+
+          </tr>
+          <tr>
+            <th scope="row">Why it matters?</th>
+            <td markdown="1">
+**These limits don’t include the matching contribution you
+may receive from your employer.** You get an **immediate tax
+break**, because contributions come out of your paycheck before
+taxes are withheld. There’s the possibility of a matching
+contribution from your employer.
+
+And you get **tax-deferred growth** — meaning you don’t pay
+taxes each year on capital gains, dividends, and other
+distributions.
+
+</td>
+          </tr>
+          <tr>
+            <th scope="row">Here’s what you
+should do now.</th>
+            <td markdown="1">
+If you are not saving to the max in your Thrift Savings Plan today,
+**consider increasing your contribution in 2018 to the IRS limit
+of $18,500** to help reach your retirement savings goals.
+</td>
+          </tr>
+        </tbody>
+    </table>
+    </div>
+  </li><li>
+    <button class="usa-accordion-button"
+      aria-expanded="false"
+      aria-controls="a3">
+      <span>$55,000</span>
+      Annual<br>Addition
+    </button>
+    <div id="a3" class="usa-accordion-content">
+    <table class="usa-table-borderless">
+        <tbody>
+          <tr>
+            <th scope="row">What’s this?</th>
+            <td markdown="1">
+## All Ages
+The annual addition is the total dollar amount contributed in a
+given year to a participant’s retirement account under a defined contribution
+plan (DC plan). This **annual addition limit is the
+lesser of 100% of the participant’s compensation for the year**
+or the dollar limit in effect for the year.
+</td>
+
+          </tr>
+          <tr>
+            <th scope="row">Why it matters?</th>
+            <td markdown="1">
+When you begin with the federal government, **you must wait
+three years years to begin receiving annual additions** to your
+retirement plan. Although you can begin contributing sooner,
+this benefit is oen delayed to ensure that employees stays in
+the position long enough to begin adding value. This period is
+called vesting. This information is on your TSP account on your
+TSP **statement** for your convenience.
+
+  </td>
+          </tr>
+          <tr>
+            <th scope="row">Here’s what you
+  should do now.</th>
+            <td markdown="1">
+Consider staying with your employer for the **vesting period**
+so you don’t miss out on free money.
+
+You’ll thank yourself later.
+  </td>
+          </tr>
+        </tbody>
+    </table>
+    </div>
+  </li>
+</ul>
+
+Grab your latest Leave and Earnings Statement and check
+out our [calculator](#), “How much should I contribute?”
+{: .usa-font-lead .text-center }


### PR DESCRIPTION
**Contribution limits**
I opted to use the alert info style we already have in place for the alert under why it matters for the $6,000 catch-up contributions section CC @Lapedra 
![screen shot 2018-08-17 at 8 25 28 am](https://user-images.githubusercontent.com/1449852/44266141-74995500-a1f7-11e8-8fd7-28bf609db8db.png)



**Top nav fix** 
![screen shot 2018-08-17 at 8 20 21 am](https://user-images.githubusercontent.com/1449852/44266131-6c411a00-a1f7-11e8-936b-f34ce82f8877.png)
