### PR TITLE
Expense ratio is now Administrative costs

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -128,6 +128,8 @@ manage-your-plan:
         href: /account-basics/protect-your-tsp-account/
       - text: Update your personal information
         href: /account-basics/update-personal-information/
+      - text: Administrative costs
+        href: /account-basics/administrative-costs/
   - text: Making contributions
     href: /making-contributions/
     subnav:

--- a/pages/account-basics/administrative-costs.md
+++ b/pages/account-basics/administrative-costs.md
@@ -1,17 +1,17 @@
 ---
-title: Expense Ratio
+title: Administrative costs
 layout: page
-permalink: /manage-life-changes/expense-ratio/
-sidenav: manage
+permalink: /account-basics/administrative-costs/
+sidenav: manage-your-plan
 styles:
 scripts:
 ---
 
-# Expense Ratio
+# Administrative costs
 If you’re looking for the best place to save and invest for your retirement, your search could be over. The TSP is a better, less expensive home for your retirement savings.
- 
-Like private sector 401 (k) plans, administering the TSP involves many kinds of expenses, and these expenses are passed on to you. But the TSP has built a solid group of investment funds that provide a broad diversification, at remarkably low cost. This is one of the reasons record numbers of you have been transferring money into the TSP from IRAs and other eligible employer plans, and you’re also keeping it in the TSP when you leave federal service. 
- 
+
+Like private sector 401 (k) plans, administering the TSP involves many kinds of expenses, and these expenses are passed on to you. But the TSP has built a solid group of investment funds that provide a broad diversification, at remarkably low cost. This is one of the reasons record numbers of you have been transferring money into the TSP from IRAs and other eligible employer plans, and you’re also keeping it in the TSP when you leave federal service.
+
 The TSP expenses are the costs of administering your TSP. The gross expenses include:
 * The costs of operating and maintaining the TSP's recordkeeping system,
 * The cost of providing participant services, and
@@ -22,4 +22,4 @@ Expenses are offset by the forfeitures of Agency/Service Automatic (1%) Contribu
 __For 2017, the average TSP net expense for participants was $.033* for every $1,000 invested.__
 The TSP net expense ratio represents the amount that participants' investment returns were reduced by TSP administrative expenses. Expense ratios may also be expressed in basis points. One basis point is 1/100th of one percent, or .01%. Therefore, the 2017 TSP net expense ratio* of .033% is 3.3 basis points. Expressed either way, this means that expenses charged to each TSP account in 2017 were approximately 33 cents per $1,000 of investment.
 
-*Fees associated with securities lending are not included in 2017 administrative expenses. Consistent with standard practice in the industry, they are charged in addition to administrative expenses. Other expenses are disclosed in the financial statements and are available in the April 2018 [*Highlights.*](https://www.tsp.gov/forms/newsletterArchive.html) 
+*Fees associated with securities lending are not included in 2017 administrative expenses. Consistent with standard practice in the industry, they are charged in addition to administrative expenses. Other expenses are disclosed in the financial statements and are available in the April 2018 [*Highlights.*](https://www.tsp.gov/forms/newsletterArchive.html)


### PR DESCRIPTION
Was: `Fund performance > Expense ratio`
Now: `Account basics > Administrative expenses`

@jamellewt @kisha16 @pamelaharrion1 and I have spoken about moving Expense ratio into its own page in Account Basics and renaming it to Administrative costs. The page itself should be moved and then retitled.

@jamellewt is filing an issue into the repo about this. I think this move is a task for @donaldferracci1 or @sswebe