### PR TITLE
Put back the link in line 30.

### DIFF
--- a/pages/making-contributions/start-change-stop-contributions.md
+++ b/pages/making-contributions/start-change-stop-contributions.md
@@ -27,6 +27,6 @@ Download the [Form TSP-1](#), _Election Form_ ([TSP-U-1](#) for uniformed servic
 
 ## I was just hired. Am I already contributing?
 
-If you're a brand new employee of the federal government or uniformed services, you were automatically enrolled in the TSP at 3% of your salary. Many people who were automatically enrolled decide to increase their contributions to at least 5% of their salary to[get the full match] (#) from their agency or service.
+If you're a brand new employee of the federal government or uniformed services, you were automatically enrolled in the TSP at 3% of your salary. Many people who were automatically enrolled decide to increase their contributions to at least 5% of their salary to[get the full match](#) from their agency or service.
 
 <!--  full match should link to "How do I get the full match?" page -->

--- a/pages/making-contributions/start-change-stop-contributions.md
+++ b/pages/making-contributions/start-change-stop-contributions.md
@@ -27,6 +27,6 @@ Download the [Form TSP-1](#), _Election Form_ ([TSP-U-1](#) for uniformed servic
 
 ## I was just hired. Am I already contributing?
 
-If you're a brand new employee of the federal government or uniformed services, you were automatically enrolled in the TSP at 3% of your salary. Many people who were automatically enrolled decide to increase their contributions to at least 5% of their salary to get the full match from their agency or service.
+If you're a brand new employee of the federal government or uniformed services, you were automatically enrolled in the TSP at 3% of your salary. Many people who were automatically enrolled decide to increase their contributions to at least 5% of their salary to[get the full match] (#) from their agency or service.
 
 <!--  full match should link to "How do I get the full match?" page -->


### PR DESCRIPTION
Minor text change. 

@line47 I initially removed the link because the infographic is no longer titled "get the full match." But upon further consideration, I think it's fine to link to the "Maximize your savings" page without saying it. Please check to make sure I added the link back properly (I don't think I did). If not, please help correct my mistake.