### PR TITLE
Add active state CSS for contribution limits table

### DIFF
--- a/_sass/components/_contribution-limits.scss
+++ b/_sass/components/_contribution-limits.scss
@@ -11,6 +11,9 @@
       margin-bottom: 1rem;
       font-size: 3rem;
     }
+    &[aria-expanded="true"] {
+      background-color: #e1f3f8;
+    }
     &[aria-expanded="true"]:after {
       content: none;
     }


### PR DESCRIPTION
@Lapedra adding `border: 1px solid #some-hex-code` to the `&[aria-expanded="true"]` declaration will allow you to experiment with different colors and widths for the active state.

![image](https://user-images.githubusercontent.com/9728434/46831927-bca9a380-cd72-11e8-8fa1-5f0e1922ba2b.png)
