### PR TITLE
RoR refactor

### DIFF
--- a/assets/js/ajaxFetch.js
+++ b/assets/js/ajaxFetch.js
@@ -71,6 +71,12 @@ function mapFundName (fund) {
   return fund.toLowerCase() + '-fund';
 }
 
+function getMonthNumber(val) {
+    var months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+    month = val.toLowerCase();
+    return months.indexOf(month);
+}
+
 function getMonthName (val) {
   var monthNames = ["January", "February", "March", "April", "May","June","July", "August", "September", "October", "November","December"];
   return monthNames[val % 12];

--- a/assets/js/rates-of-returns.js
+++ b/assets/js/rates-of-returns.js
@@ -145,9 +145,6 @@ function fundYvalueFormat(value) {
 }
 
 function fundCheckboxClick(chartName, cbName) {
-  // console.log('fundCheckboxClick', chartName, cbName);
-  deleteEmptyPoints(chartName+'-annual');
-  deleteEmptyPoints(chartName+'-monthly');
   fundCheckboxClickAction(chartName+"-monthly", cbName);
   fundCheckboxClickAction(chartName+"-annual", cbName);
   return false;
@@ -160,8 +157,6 @@ function fundHighchartClick(chartName, idx, name, vis) {
   } else {
     otherChart = chartName.replace('-monthly', '-annual');
   }
-  deleteEmptyPoints(chartName);
-  deleteEmptyPoints(otherChart);
   fundHighchartClickBuddy(chartName, idx, name, vis);
   fundHighchartClickBuddy(otherChart, idx, name, vis);
   return false;

--- a/assets/js/rates-of-returns.js
+++ b/assets/js/rates-of-returns.js
@@ -98,7 +98,7 @@ function buildSideScrollTableRoR(chartName, data) {
       var id = "year_"+yearName;
       val = '<label id="'+id+'_label" for="'+id+'">'+yearName+YTD+'</label>';
       val += '<input type="checkbox" id="'+id+'" onClick="toggleTableMonths(\''+id+'\')">';
-      col[0] = col[0] = Date.UTC(col[0].substr(0, 4), 0);
+      col[0] = Date.UTC(col[0].substr(0, 4), 0);
       annualData.unshift(col.join(","));
       row = sideScrollTH('', '', '', val, false);
       YTD = '';

--- a/assets/js/rates-of-returns.js
+++ b/assets/js/rates-of-returns.js
@@ -90,15 +90,15 @@ function buildSideScrollTableRoR(chartName, data) {
     yearName = col[0].substr(0,4);
     if (lineType == 'm') {
       monthName = getMonthName(parseInt(col[0].substr(4, 2))-1);
-      val = monthName; //  + ' ' + yearName;
-      col[0] = monthName + ' ' + yearName;
+      val = monthName;
+      col[0] = Date.UTC(col[0].substr(0, 4), col[0].substr(4, 2)-1);
       monthlyData.unshift(col.join(","));
       row = sideScrollTH('', '', '', val, false);
     } else {
       var id = "year_"+yearName;
       val = '<label id="'+id+'_label" for="'+id+'">'+yearName+YTD+'</label>';
       val += '<input type="checkbox" id="'+id+'" onClick="toggleTableMonths(\''+id+'\')">';
-      col[0] = yearName;
+      col[0] = col[0] = Date.UTC(col[0].substr(0, 4), 0);
       annualData.unshift(col.join(","));
       row = sideScrollTH('', '', '', val, false);
       YTD = '';
@@ -121,7 +121,7 @@ function buildSideScrollTableRoR(chartName, data) {
   // console.log(headerHTML+bodyHTML);
   // console.log(table);
   annualData.unshift(header);
-  monthlyData.unshift(header);
+  monthlyData.unshift(header.replace("Year","Month"));
   // console.log(annualData);
   fundHighchart(chartName+'-annual', annualData.join("\n"), '', true);
   fundHighchart(chartName+'-monthly', monthlyData.join("\n"), '', true);
@@ -190,17 +190,16 @@ function fundHighchartClickBuddy(chartName, idx, fundName, vis) {
 }
 
 function fundTooltip(me, chartName) {
-  // console.log(me);
   var rc = fundTooltipBody(me);
-  var tipTitle = getMonthYearName(me.x+1000000000);
-  // if (chartName.includes('-annual')) {
+  var tipTitle; 
   if (chartName.indexOf('-annual') > -1) {
-    tipTitle = 'Annual Returns ';
-    if ((me.x + 1) > me.points[0].series.xAxis.max) { tipTitle = 'YTD Returns '}
-    tipTitle += me.x;
+      tipTitle = 'Annual Returns ';
+      if ((me.x + 11098432000) > me.points[0].series.xAxis.max) { tipTitle = 'YTD Returns ' }
+      tipTitle += new Date(me.points[0].key).getUTCFullYear();
+  } else {
+      tipTitle = getMonthName(new Date(me.points[0].key).getUTCMonth()) + ' ' + new Date(me.points[0].key).getUTCFullYear();
   }
   rc = tooltipHeader(tipTitle)+rc;
   rc = tooltipDiv('rates-of-return'+'-tooltip', rc);
-  // console.log(rc);
   return rc;
 }

--- a/assets/js/share-price-history.js
+++ b/assets/js/share-price-history.js
@@ -77,7 +77,7 @@ function buildSideScrollTableSH(chartName, data) {
   // loop on each row, body groups
   var bodyHTML = '';
   // highcharts likes low to high, we want table high to low
-  for (j = lines.length-1; j > 0; j--) {
+  for (j = lines.length-1; j >= 0; j--) {
     if (lines[j].trim() == '') { continue; }
     row = '';
     var col = lines[j].split(",");

--- a/assets/js/share-price-history.js
+++ b/assets/js/share-price-history.js
@@ -44,21 +44,22 @@ function getSharePricesRaw(chart) {
   return false;
 }
 
-// prep no longer needed, server sends in hc format
 function prepDataforHighchart(data) {
-  var lines = data.split("\n");
-  var header = lines.shift();
-  var col = header.split(",");
-  for (var i = 1; i < col.length; i++) { col[i] = mapServerFundName(col[i], false); }
-  lines.reverse();
-  lines[0] = col.join(",");
-  return lines.join("\n");
-  lines.shift();
-  lines.reverse();
-  lines.unshift(col.join(","));
-  // lines[0] = col.join(",");
-  data = lines.join("\n");
+    var lines = data.split("\n");
+    for (var i = 1; i < lines.length; i++) {
+        var line = lines[i].split(",");
+        if (line[0] !== "") {
+            var elements = line[0].split(/[ \.]/);
+            line[0] = Date.UTC(elements[3], getMonthNumber(elements[0]), elements[1]);
+            lines[i] = line.join(",");
+        } else {
+            lines.length = i;
+            break;
+        }
+    }
+    return lines.join("\n");
 }
+
 function buildSideScrollTableSH(chartName, data) {
   var i, j, colClass, row;
   var lines = data.split("\n");
@@ -104,7 +105,8 @@ var doAjaxRetrieveRaw = function(divName, url) {
   var serverCall = $.get(url);
   serverCall.done(
     function (data) {
-      var chart = fundHighchart(divName, data, '', false);
+      var chartdata = prepDataforHighchart(data);
+      var chart = fundHighchart(divName, chartdata, '', false);
       $('#'+divName+'-table').html(buildSideScrollTableSH(divName, data));
       syncCheckboxes(divName);
       chartResize(divName);

--- a/assets/js/side-scroll-funds.js
+++ b/assets/js/side-scroll-funds.js
@@ -98,7 +98,8 @@ function syncCheckboxByName(chartName, cbName) {
   return false;
 }
 
-function indexFundSync(chartName, doTableColumn) {
+function indexFundSync(chartName, doTableColumn, noredraw) {
+  var noredraw = noredraw || false;
   if ($('#Index').length <= 0) { return false; };
   var val = $('#Index').prop('checked');  // get its new value
   var chart = $('#'+chartName).highcharts();
@@ -112,7 +113,7 @@ function indexFundSync(chartName, doTableColumn) {
   if (val) fundHighchartClickAction(chartName, 16, '&', series[10].visible);
   highchartsSeriesToggle(series, 18, val, doTableColumn);
   if (val) fundHighchartClickAction(chartName, 18, '&', series[12].visible);
-  chart.redraw();
+  if (!noredraw) { chart.redraw() };
   return false;
 }
 
@@ -120,7 +121,7 @@ function indexFundSync(chartName, doTableColumn) {
 function highchartsSeriesToggle(series, idx, show, doTableColumn) {
   if (idx < 0) { return false; }
   if (idx >= series.length) { return false; }
-  series[idx].update({ showInLegend: show }, true, false);
+  series[idx].update({ showInLegend: show }, false);
   if (!show) { series[idx].setVisible(show, false); }
   if (doTableColumn) { syncTableColumn(idx+1, show); }
   return false;
@@ -128,10 +129,8 @@ function highchartsSeriesToggle(series, idx, show, doTableColumn) {
 
 // sync visibility after reloading data
 function syncCheckboxes(chartName) {
-  indexFundSync(chartName, true);
+  indexFundSync(chartName, true, true);
   syncCheckboxByName(chartName, 'L_Income');
-  // syncCheckboxByName(chartName, 'L_2010');
-  // syncCheckboxByName(chartName, 'L_2020');
   syncCheckboxByName(chartName, 'L_2025');
   syncCheckboxByName(chartName, 'L_2030');
   syncCheckboxByName(chartName, 'L_2035');
@@ -147,8 +146,15 @@ function syncCheckboxes(chartName) {
   syncCheckboxByName(chartName, 'S_Fund');
   syncCheckboxByName(chartName, 'I_Fund');
   syncFundCheckboxGroups();
+  redraw(chartName);
   return false;
 }
+
+function redraw(chartName) {
+    var chart = $('#' + chartName).highcharts();
+    chart.redraw();
+}
+
 
 // map cb name to index in fund list
 function checkBoxColumnID(cbName, indexFundsFlag) {
@@ -199,7 +205,7 @@ function setSeriesVisibility(chart, idx, val) {
   if (chart == null) { return; }
   var series = chart.series;
   if (idx >= series.length) { return false; }
-  series[idx].setVisible(val, true);
+  series[idx].setVisible(val, false);
   return -1;
 }
 function syncTableColumn(col,vis) {

--- a/assets/js/side-scroll-funds.js
+++ b/assets/js/side-scroll-funds.js
@@ -273,7 +273,7 @@ function fundHighchart(chartName, csvData, title, indexFundsFlag) {
       },
       title: { text: '' }
     },
-    // xAxis: { uniqueNames: false },
+    xAxis: { type: 'datetime' },
     tooltip: {
       formatter: function () {
         return fundTooltip(this, chartName);


### PR DESCRIPTION
Patch for Rate of Return / sidescroll js.  

1- Fixes issue in IE 11 & Edge where clicking a checkbox would result in incorrect data being displayed on the monthly graph
2- Improved load times

Speed tested on the following browsers:
Browser|Before|After
------------ | ------------- | -------------
Chrome|22s|3.5s
IE11|54s|9s
Edge|24s|3s

Testing still needed on mobile browsers and Firefox.

The load time issue was caused by multiple redraw calls that drove multiple layout changes each time new data was added to the chart.  Deferring those redraws reduced the number of layouts and improves speed.  This also improves speed on the share price table which uses the same code but has simpler charts so render times not as problematic as RoR.

The IE/Edge issue was due to the xAxis being loaded as a categorical axis and not a date/time, which apparently certain browser then did not link the data points to the correct index of the axis.  Switching to datetime sorted that out.