### PR TITLE
Add {{ sitebase.url }} to Forms and resources code

### DIFF
--- a/_data/forms.yml
+++ b/_data/forms.yml
@@ -206,8 +206,7 @@
   form_topics:
   -  General information
 - form_number: TSP-75
-  form_url: https://secure.tsp.gov/tsp/addlWithdrawals.do?subaction=wdMenu&_name=wd&_form=tsp75
-#  form_url: "{{ site.loans }}&_form=tsp75"
+  form_url: "{{ site.withdrawals }}&_form=tsp75"
   form_name: Age-Based In-Service Withdrawal Request
   form_info: Request a withdrawal from your TSP account if you are age 59½ or older and still employed by the Federal Government.
   form_date: 2/2015
@@ -217,8 +216,7 @@
   form_topics:
   -  Withdrawals
 - form_number: TSP-76
-  form_url: https://secure.tsp.gov/tsp/addlWithdrawals.do?subaction=wdMenu&_name=wd&_form=tsp76
-#  form_url: "{{ site.loans }}&_form=tsp76"
+  form_url: "{{ site.withdrawals }}&_form=tsp76"
   form_name: Financial Hardship In-Service Withdrawal Request
   form_info: Request a financial hardship withdrawal while still employed.
   form_date: 1/2018
@@ -258,8 +256,7 @@
   form_topics:
   -  Legal documents
 - form_number: TSP-95
-  form_url: https://secure.tsp.gov/tsp/addlWithdrawals.do?subaction=wdMenu&_name=wd&_form=tsp95
-  #  form_url: "{{ site.loans }}&_form=tsp95"
+  form_url: "{{ site.withdrawals }}&_form=tsp95"
   form_name: Changes to Installment Payments
   form_info: Log in to [My Account]({{ site.withdrawals }}) and access the online tool to request changes to your existing TSP installment payments.
   form_date: Local reproduction
@@ -269,8 +266,7 @@
   form_topics:
   -  Withdrawals
 - form_number: TSP-96
-  form_url: https://secure.tsp.gov/tsp/addlWithdrawals.do?subaction=wdMenu&_name=wd&_form=tsp96
-#  form_url: "{{ site.loans }}&_form=tsp96"
+  form_url: "{{ site.withdrawals }}&_form=tsp96"
   form_name: CARES Act Withdrawal Request
   form_info: Apply online for a withdrawal of up to $100,000. **Only for participants affected by COVID-19** as defined in the CARES Act (P.L. 116-136).
   form_date: Local reproduction
@@ -280,8 +276,7 @@
   form_topics:
   -  Withdrawals
 - form_number: TSP-99
-  form_url: https://secure.tsp.gov/tsp/addlWithdrawals.do?subaction=wdMenu&_name=wd&_form=tsp99
-  #  form_url: "{{ site.loans }}&_form=tsp99"
+  form_url: "{{ site.withdrawals }}&_form=tsp99"
   form_name: Withdrawal Request for Separated and Beneficiary Participants
   form_info: Log in to [My Account]({{ site.withdrawals }}) and access the online tool to request a withdrawal if you are either separated from service or a beneficiary participant.
   form_date: Local reproduction

--- a/_data/forms.yml
+++ b/_data/forms.yml
@@ -287,7 +287,7 @@
   -  Withdrawals
   -  Beneficiary participants
 - form_number: W-4P
-  form_url: /exit/?idx=26
+  form_url: "{{ site.baseurl }}/exit/?idx=26"
   form_name: Withholding Certificate for Pension or Annuity Payments
   form_info: Request a change to the default tax withholding for a withdrawal. W-4P is an IRS form.
   form_date: Local Reproduction

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -32,7 +32,7 @@
   - Annuity
   publication_topics:
   - Withdrawals
-- publication_url: /annuity-basics/historical-annuity-rates/
+- publication_url: "{{ site.baseurl }}/annuity-basics/historical-annuity-rates/"
   publication_name: Annuity rates (historical)
   publication_info: View monthly annuity rates from 2002 through the present. Also available for export.
   publication_date: 9/2020

--- a/_includes/components/forms-list.html
+++ b/_includes/components/forms-list.html
@@ -1,7 +1,7 @@
 <ul class="forms-list">
 {% for form in sorted %}
   <li>
-    <a href="/forms/{{ form.form_url }}" class="form-name">
+    <a href="{{ site.baseurl }}/forms/{{ form.form_url }}" class="form-name">
       {{ form.form_name }}
     </a> <span class="form-date">{{ form.form_date }}</span>
     <span class="form-info">{{ form.form_info }}</span>

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -5,10 +5,10 @@ Calculate absolute URL for a collection item.
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
-{% assign abzURL = '{{ site.baseurl }}' | append: rawURL %}
+{% assign relURL = '{{ site.baseurl }}' | append: rawURL %}
 
-{% assign prefixURL = rawURL | slice: 0 %}
-{% if prefixURL == '/' %}{% assign absURL = abzURL %}{% endif %}
+{% assign prefixURL = rawURL | slice: 0, 1 %}
+{% if prefixURL == '/' %}{% assign absURL = relURL %}{% endif %}
 
 {% assign prefixURL = rawURL | slice: 0, 4 %}
 {% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
@@ -17,7 +17,7 @@ Calculate absolute URL for a collection item.
 {% if resource.publication_url contains 'site' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
 
 {% comment %}
-(form.form_url contains 'site') and (resource.publication_url contains 'site') prevent My Account links from being prepended with /forms/ or /publications/.
+[form.form_url contains 'site'] and [resource.publication_url contains 'site'] prevent My Account links from being prepended with curPath — either /forms/ or /publications/.
 {% endcomment %}
 
 {% comment %}

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -1,7 +1,7 @@
 {% comment %}
 Calculate absolute URL for a collection item.
 {% endcomment %}
-{% assign curPath = include.curPath | default: '/forms/' %}
+{% assign curPath = include.curPath | default: '{{ site.baseurl }}/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
 {% assign prefixURL = rawURL | slice: 0 %}

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -1,7 +1,7 @@
 {% comment %}
 Calculate absolute URL for a collection item.
 {% endcomment %}
-{% assign curPath = include.curPath | default: '{{ site.baseurl }}/forms/' %}
+{% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
 {% assign prefixURL = rawURL | slice: 0 %}

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -5,10 +5,6 @@ Calculate absolute URL for a collection item.
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
-{% assign relURL = rawURL %}
-
-{% assign prefixURL = rawURL | slice: 0, 1 %}
-{% if prefixURL == '/' %}{% assign absURL = relURL %}{% endif %}
 
 {% assign prefixURL = rawURL | slice: 0, 4 %}
 {% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
@@ -18,15 +14,10 @@ Calculate absolute URL for a collection item.
 
 
 {% comment %}
-[form.form_url contains 'site'] and [resource.publication_url contains 'site'] prevent My Account links from being prepended with curPath — either /forms/ or /publications/.
+(if prefixURL == 'http') and (if prefixURL contains 'site') prevent My Account links from being prepended with curPath — either /forms/ or /publications/.
 {% endcomment %}
 
 {% comment %}
-
-{% assign prefixURL = rawURL | slice: 0, 4 %}
-{% if resource.publication_url contains 'site' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
-
-
 ORIGINAL CODE
 Calculate absolute URL for a collection item.
 

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -5,7 +5,7 @@ Calculate absolute URL for a collection item.
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
-{% assign relURL = '{{ site.baseurl }}' | append: rawURL %}
+{% assign relURL = rawURL %}
 
 {% assign prefixURL = rawURL | slice: 0, 1 %}
 {% if prefixURL == '/' %}{% assign absURL = relURL %}{% endif %}
@@ -13,14 +13,20 @@ Calculate absolute URL for a collection item.
 {% assign prefixURL = rawURL | slice: 0, 4 %}
 {% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
 
-{% assign prefixURL = rawURL | slice: 0, 4 %}
-{% if resource.publication_url contains 'site' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+{% assign prefixURL = rawURL | slice: 0, 7 %}
+{% if prefixURL contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+
 
 {% comment %}
 [form.form_url contains 'site'] and [resource.publication_url contains 'site'] prevent My Account links from being prepended with curPath — either /forms/ or /publications/.
 {% endcomment %}
 
 {% comment %}
+
+{% assign prefixURL = rawURL | slice: 0, 4 %}
+{% if resource.publication_url contains 'site' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+
+
 ORIGINAL CODE
 Calculate absolute URL for a collection item.
 

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -7,4 +7,7 @@ Calculate absolute URL for a collection item.
 {% assign prefixURL = rawURL | slice: 0 %}
 {% if prefixURL == '/' %}{% assign absURL = rawURL %}{% endif %}
 {% assign prefixURL = rawURL | slice: 0, 4 %}
-{% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
+{% if prefixURL == 'http' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+{% comment %}
+form.form_url contains 'site' prevents My Account links from being prepended with /forms/
+{% endcomment %}

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -5,6 +5,10 @@ Calculate absolute URL for a collection item.
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
+{% assign abzURL = '{{ site.baseurl }}' | append: rawURL %}
+
+{% assign prefixURL = rawURL | slice: 0 %}
+{% if prefixURL == '/' %}{% assign absURL = abzURL %}{% endif %}
 
 {% assign prefixURL = rawURL | slice: 0, 4 %}
 {% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
@@ -23,6 +27,8 @@ Calculate absolute URL for a collection item.
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
+{% assign prefixURL = rawURL | slice: 0 %}
+{% if prefixURL == '/' %}{% assign absURL = rawURL %}{% endif %}
 {% assign prefixURL = rawURL | slice: 0, 4 %}
 {% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
 

--- a/_includes/components/testURL.html
+++ b/_includes/components/testURL.html
@@ -1,13 +1,29 @@
+
 {% comment %}
 Calculate absolute URL for a collection item.
 {% endcomment %}
 {% assign curPath = include.curPath | default: '/forms/' %}
 {% assign rawURL = include.rawURL | default: 'index.html' %}
 {% assign absURL = curPath | append: rawURL %}
-{% assign prefixURL = rawURL | slice: 0 %}
-{% if prefixURL == '/' %}{% assign absURL = rawURL %}{% endif %}
+
 {% assign prefixURL = rawURL | slice: 0, 4 %}
-{% if prefixURL == 'http' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+{% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
+
+{% assign prefixURL = rawURL | slice: 0, 4 %}
+{% if resource.publication_url contains 'site' or form.form_url contains 'site' %}{% assign absURL = rawURL %}{% endif %}
+
 {% comment %}
-form.form_url contains 'site' prevents My Account links from being prepended with /forms/
+(form.form_url contains 'site') and (resource.publication_url contains 'site') prevent My Account links from being prepended with /forms/ or /publications/.
+{% endcomment %}
+
+{% comment %}
+ORIGINAL CODE
+Calculate absolute URL for a collection item.
+
+{% assign curPath = include.curPath | default: '/forms/' %}
+{% assign rawURL = include.rawURL | default: 'index.html' %}
+{% assign absURL = curPath | append: rawURL %}
+{% assign prefixURL = rawURL | slice: 0, 4 %}
+{% if prefixURL == 'http' %}{% assign absURL = rawURL %}{% endif %}
+
 {% endcomment %}

--- a/_includes/forms/form.html
+++ b/_includes/forms/form.html
@@ -22,7 +22,7 @@
       {% endif %}
     <p class="form-title">{{ form.form_name}}</p>
     <p class="form-number">
-      <a href="{{ formURL | liquify }}" xxx="{{ prefixURL }}" class="form-name">
+      <a href="{{ site.baseurl }}{{ formURL | liquify }}" xxx="{{ prefixURL }}" class="form-name">
         Form {{ form.form_number}}
       </a>
     </p>

--- a/_includes/forms/form.html
+++ b/_includes/forms/form.html
@@ -24,10 +24,10 @@
     <p class="form-number">
       {% if formURL == rawURL %}
       <!-- Omit site.baseurl for http links -->
-      <a href="{{ formURL | liquify }}" xxx="rawURL {{ prefixURL }}" class="form-name">
+      <a href="{{ formURL | liquify }}" xxx="rawURL" class="form-name">
         {% else %}
       <!-- Inclucde site.baseurl for internal links -->
-      <a href="{{ site.baseurl }}{{ formURL | liquify }}" xxx="{{ prefixURL }}" class="form-name">
+      <a href="{{ site.baseurl }}{{ formURL | liquify }}" xxx="absURL" class="form-name">
       {% endif %}
         Form {{ form.form_number}}
       </a>

--- a/_includes/forms/form.html
+++ b/_includes/forms/form.html
@@ -22,7 +22,13 @@
       {% endif %}
     <p class="form-title">{{ form.form_name}}</p>
     <p class="form-number">
+      {% if formURL == rawURL %}
+      <!-- Omit site.baseurl for http links -->
+      <a href="{{ formURL | liquify }}" xxx="rawURL {{ prefixURL }}" class="form-name">
+        {% else %}
+      <!-- Inclucde site.baseurl for internal links -->
       <a href="{{ site.baseurl }}{{ formURL | liquify }}" xxx="{{ prefixURL }}" class="form-name">
+      {% endif %}
         Form {{ form.form_number}}
       </a>
     </p>

--- a/_includes/forms/resource.html
+++ b/_includes/forms/resource.html
@@ -22,7 +22,7 @@
     <i class="{{ icon }}"></i>
     </div>
     <div class="resource-title">
-      <p><a href="{{ pubURL }}" class="">
+      <p><a href="{{site.baseurl }}{{ pubURL }}" class="">
         {{ resource.publication_name }}</a></p>
       <p><small>{{ resource.publication_type }}</small></p>
     </div>

--- a/_includes/forms/resource.html
+++ b/_includes/forms/resource.html
@@ -22,7 +22,14 @@
     <i class="{{ icon }}"></i>
     </div>
     <div class="resource-title">
-      <p><a href="{{site.baseurl }}{{ pubURL }}" class="">
+      <p>
+        {% if pubURL == rawURL %}
+        <!-- Omit site.baseurl for http links -->
+        <a href="{{ pubURL | liquify }}" xxx="rawURL" class="">
+          {% else %}
+        <!-- Inclucde site.baseurl for internal links -->
+        <a href="{{site.baseurl }}{{ pubURL }}" class="">
+        {% endif %}
         {{ resource.publication_name }}</a></p>
       <p><small>{{ resource.publication_type }}</small></p>
     </div>

--- a/_includes/forms/resource.html
+++ b/_includes/forms/resource.html
@@ -28,7 +28,7 @@
         <a href="{{ pubURL | liquify }}" xxx="rawURL" class="">
           {% else %}
         <!-- Inclucde site.baseurl for internal links -->
-        <a href="{{site.baseurl }}{{ pubURL }}" class="">
+        <a href="{{site.baseurl }}{{ pubURL | liquify }}" xxx="absURL" class="">
         {% endif %}
         {{ resource.publication_name }}</a></p>
       <p><small>{{ resource.publication_type }}</small></p>


### PR DESCRIPTION
- Forms and pubs links break in federalist branch preview due to missing {{ site.baseurl }}
- Refactored testURL.html to include it for relative links, omit it for external links.