### PR TITLE
Northcutt SEO audit remediation

### DIFF
--- a/pages/account-basics/access-your-account.md
+++ b/pages/account-basics/access-your-account.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Account basics
+title: Access your account
 sidenav: manage-your-plan
 styles:
 scripts:

--- a/pages/account-basics/administrative-costs.md
+++ b/pages/account-basics/administrative-costs.md
@@ -1,6 +1,6 @@
 ---
-title: Administrative costs
 layout: page
+title: Administrative costs
 permalink: /account-basics/administrative-costs/
 sidenav: manage-your-plan
 styles:

--- a/pages/account-basics/protect-your-tsp-account.md
+++ b/pages/account-basics/protect-your-tsp-account.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Account basics
+title: Protect your TSP account
 sidenav: manage-your-plan
 styles:
 scripts:

--- a/pages/account-basics/troubleshoot-login-errors.md
+++ b/pages/account-basics/troubleshoot-login-errors.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Account basics
+title: Troubleshoot account access
 sidenav: manage-your-plan
 styles:
 scripts:

--- a/pages/account-basics/update-your-address.md
+++ b/pages/account-basics/update-your-address.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Account basics
+title: Update your address
 sidenav: manage-your-plan
 styles:
 scripts:
@@ -12,7 +12,7 @@ Keeping your addresss up to date with us is important. How you change your addre
 
 **If you’re currently a federal employee**, report your correct address to your agency. We can’t accept address changes directly from you.
 
-**If you're an active or a Ready Reserve member of the Air Force, Army, Navy, or Marine Corps**, you can update your address through the [myPay]({{ site.baseurl }}/exit/?idx=6){:rel="nofollow"} website. Just make sure that you log in and go to the TSP section to change your TSP address. If you change it in the “Correspondence Address” section of myPay, it will not change your TSP address. 
+**If you're an active or a Ready Reserve member of the Air Force, Army, Navy, or Marine Corps**, you can update your address through the [myPay]({{ site.baseurl }}/exit/?idx=6){:rel="nofollow"} website. Just make sure that you log in and go to the TSP section to change your TSP address. If you change it in the “Correspondence Address” section of myPay, it will not change your TSP address.
 
 Members of the Coast Guard and NOAA Corps can use [Direct Access]({{ site.baseurl }}/exit/?idx=47){:rel="nofollow"}. Select "Home and Mailing Address" under Tasks, then choose "TSP" from the drop-down menu next to "Address Type."
 

--- a/pages/agency-service-reps/historical-information.md
+++ b/pages/agency-service-reps/historical-information.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Historical information on contribution limits
+title: Historical contribution limits
 styles:
 sidenav: agency-service-reps
 scripts:

--- a/pages/calculators/index.md
+++ b/pages/calculators/index.md
@@ -1,6 +1,6 @@
 ---
 layout: calculator
-title: How much should I save? (Federal Ballpark E$timate&#174;)
+title: How much should I save?
 title-alternate: How much should I save? <br>(Federal Ballpark E$timate<sup>&#174;</sup>)
 styles:
 sidenav: calculators

--- a/pages/funds-retired/index.md
+++ b/pages/funds-retired/index.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Lifecycle funds
+title: Retired Lifecycle (L) Funds
 styles:
 sidenav: fund-options
 scripts:

--- a/pages/making-contributions/contribution-types.md
+++ b/pages/making-contributions/contribution-types.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Making contributions
+title: Contribution types
 styles:
 sidenav: manage-your-plan
 scripts:

--- a/pages/making-contributions/traditional-and-roth-contributions.md
+++ b/pages/making-contributions/traditional-and-roth-contributions.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Making contributions
+title: Traditional and Roth contributions
 styles:
 sidenav: manage-your-plan
 scripts:


### PR DESCRIPTION
- Shortened long (>140 characters) page titles.
- Corrected redundant page titles.