### PR TITLE
Restore "Troubleshoot account access"

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -116,8 +116,8 @@ manage-your-plan:
         href: /account-basics/move-money-into-tsp/
       - text: Protect your TSP account
         href: /account-basics/protect-your-tsp-account/
-      - text: Troubleshoot login errors
-        href: /account-basics/troubleshoot-login-errors/
+      - text: Troubleshoot account access
+        href: /account-basics/troubleshoot-account-access/
       - text: Update your address
         href: /account-basics/update-your-address/
       - text: Administrative costs

--- a/pages/account-basics/troubleshoot-account-access.md
+++ b/pages/account-basics/troubleshoot-account-access.md
@@ -4,8 +4,10 @@ title: Troubleshoot account access
 sidenav: manage-your-plan
 styles:
 scripts:
-permalink: /account-basics/troubleshoot-login-errors/
-redirect_from: /sitehelp/
+permalink: /account-basics/troubleshoot-account-access/
+redirect_from:
+  - /sitehelp/
+  - /account-basics/troubleshoot-login-errors/
 
 ---
 # Troubleshoot account access

--- a/pages/account-basics/troubleshoot-login-errors.md
+++ b/pages/account-basics/troubleshoot-login-errors.md
@@ -1,17 +1,32 @@
 ---
 layout: page
-title: Account basics
+title: Troubleshoot account access
 sidenav: manage-your-plan
 styles:
 scripts:
 permalink: /account-basics/troubleshoot-login-errors/
 redirect_from: /sitehelp/
+
 ---
 # Troubleshoot account access
 
 ## 3 most common TSP account problems and solutions
 
-### 1. I didn’t receive my one-time code, or the code I received isn’t working.
+### 1. I don’t know my account access information.
+
+You need your <span data-term="User ID" class="js-glossary-toggle term term-end">user ID</span> and <span data-term="Password" class="js-glossary-toggle term term-end">password</span> to log in to My Account.
+
+- **User ID** — If you don’t have a user ID, you must [create a user ID]({{ site.userid_create }}). If you’ve forgotten your user ID, you may be able to [recover your user ID]({{ site.userid_forgot }}) online.
+
+- **Password** — You may be able to [reset your password]({{ site.myaccount }}) online.
+
+You need your TSP <span data-term="Account Number" class="js-glossary-toggle term term-end">account number</span> and <span data-term="Personal Identification Number (PIN)" class="js-glossary-toggle term term-end">personal identification number (PIN)</span> to access your account information and perform certain transactions on the <span data-term="ThriftLine" class="js-glossary-toggle term term-end">ThriftLine</span>.
+
+- **Account number** — You can request your account number online or [call the ThriftLine]({{ site.baseurl }}/contact/) to speak to a TSP representative. We will mail your account number to the address on your TSP account. You should receive it within 3 – 5 business days.
+
+- **Personal Identification Number (PIN)** — If you forget your PIN, you can request a new one when you [call the ThriftLine]({{ site.baseurl }}/contact/).
+
+### 2. I didn’t receive my one-time code, or the code I received isn’t working.
 
 **If your one-time code doesn’t arrive until after the expiration period,** you won’t be able to use the code and will need to begin your request again to receive a new code.
 
@@ -24,41 +39,15 @@ Phone carrier network disruptions and a poor cellular connection are the most co
 
 If you aren’t sure which code is the most recent, or your code has expired, you can try your request again to receive a new code.
 
-### 2. I don’t know my account access information.
+### 3. I don’t have a phone number that I can validate, or I can’t access my validated phone number.
 
-You need your user ID and password to log in to My Account.
-
-**User ID**
-
-- If you don’t have a user ID, you must create a user ID.
-
-- If you’ve forgotten your user ID, you may be able to recover your
-        user ID online.
-
-**Password**
-
-- You may be able to reset your password online.
-
-You need your account number and personal identification number (PIN) to access your account information and perform certain transactions on the ThriftLine.
-
-**Account number**
-
-- You can request your account number online or [call the ThriftLine]({{ site.baseurl }}/contact/) to speak to a TSP representative.
-
-We will mail your account number to the address on your TSP account. You should receive it within 3 – 5 business days.
-
-**Personal Identification Number (PIN)**
-
-- If you forget your PIN, you can request a new one when you [call the ThriftLine]({{ site.baseurl }}/contact/).
-
-### 3. I can’t access my validated phone number, or I don’t have a phone number that I can validate.
+**If you don’t have access to phone service, you might consider using an online service that allows you to receive text messages and phone calls through an internet connection.** These services use a technology called VoIP (voice over internet protocol). Most VoIP services require that you establish an account with them and will then issue you a phone number. You may add and validate a VoIP phone number on your TSP account and use it for verification purposes. Keep in mind that the TSP has not done a security assessment on these services and does not endorse any specific service. As with all your online accounts, make sure you enable any additional security features to further [protect your TSP account]({{ site.baseurl }}/account-basics/protect-your-tsp-account/).
 
 **If you lose access to your validated phone number,** [call the ThriftLine]({{ site.baseurl }}/contact/) to speak to a TSP representative. After verifying your identity, the TSP representative will help you add and validate a new phone number.
 
-**If you have an international phone number,** you can validate it by text message or phone call. It’s important to include the correct country code for your international number. When you add your phone number in My Account, select the checkbox to indicate that this is an international phone number. A new field will appear to allow you to input the country code.
+**You can validate any phone number that receives calls.** When you choose to receive a one-time code by phone call, you’ll receive an automated call that voices your code aloud. Note: our system cannot validate phone numbers on the Defense Switched Network (DSN).
 
-**Keep in mind that you can validate any phone number that receives calls.**   
-When you choose to receive a one-time code by phone call, you’ll receive an automated call that voices your code aloud. Note: our system cannot validate phone numbers on the Defense Switched Network (DNS).
+**If you have an international phone number,** you can validate it by text message or phone call. It’s important to include the correct country code for your international number. When you add your phone number in My Account, select the checkbox to indicate that this is an international phone number. A new field will appear to allow you to input the country code.
 
 **If you are unable or unwilling to provide your phone number,** you may be unable to log in to My Account because you will be unable to complete two-step authentication.
 
@@ -76,7 +65,7 @@ You can access your account information and perform certain transactions, such a
     My financial aggregator or app or service on another website stopped working.
   </button>
   <div id="other-1" class="usa-accordion-content" markdown="1">
-  If you give your account credentials to a third-party application, you may receive a verification code each time that application attempts to retrieve information from your TSP account. Providing your TSP account credentials to a third-party application [may put your account security at risk]({{ site.baseurl }}/account-basics/protect-your-tsp-account/).
+  If you give your account credentials to a third-party application, you may receive a <span data-term="Verification Code" class="js-glossary-toggle term term-end">verification code</span> each time that application attempts to retrieve information from your TSP account. Providing your TSP account credentials to a third-party application [may put your account security at risk]({{ site.baseurl }}/account-basics/protect-your-tsp-account/).
 
   We recommend that you only log in to My Account through [secure.tsp.gov]({{ site.myaccount }}). The TSP cannot endorse any information or advice from third-party applications or services.
   </div>
@@ -90,9 +79,9 @@ You can access your account information and perform certain transactions, such a
     I can’t get back to the page to input my one-time code.
   </button>
   <div id="other-2" class="usa-accordion-content" markdown="1">
-  **If you make a request that requires two-step authentication** and navigate away from the verification code input, you need to start over and make your request again to receive a new code.
+  **If you make a request that requires <span data-term="Two-step authentication" class="js-glossary-toggle term term-end">two-step authentication</span>** and navigate away from the <span data-term="Verification Code" class="js-glossary-toggle term term-end">verification code</span> input, you need to start over and make your request again to receive a new code.
 
-  **If you’re trying to validate an email or phone number,** you can use the link in the validation code email or text message to return to the page where you input your validation code. **If you are no longer logged in, you’ll be prompted to log in again and may need to complete two-step authentication before you can complete the process to validate your contact information.** Remember that the validation code expires after one hour.
+  **If you’re trying to validate an email or phone number,** you can use the link in the <span data-term="Validation Code" class="js-glossary-toggle term term-end">validation code</span> email or text message to return to the page where you input your validation code. **If you are no longer logged in, you’ll be prompted to log in again and may need to complete <span data-term="Two-step authentication" class="js-glossary-toggle term term-end">two-step authentication</span> before you can complete the process to validate your contact information.** Remember that the validation code expires after one hour.
   </div>
 </li>
 
@@ -116,13 +105,11 @@ You can access your account information and perform certain transactions, such a
     I have both a civilian and a uniformed services TSP account.
   </button>
   <div id="other-4" class="usa-accordion-content" markdown="1">
-  If you have both a civilian and a uniformed services TSP account, you need to set up your passwords to either connect them in My Account or to keep the login information separate.
+  If you have both a civilian and a uniformed services TSP account, you need to set up your passwords to either connect them in My Account or to keep their login information separate.
 
-  Your account number and user ID are the same for both your civilian and uniformed services accounts.
+  Your <span data-term="Account Number" class="js-glossary-toggle term term-end">account number</span> and <span data-term="User ID" class="js-glossary-toggle term term-end">user ID</span> are the same for both your civilian and uniformed services accounts.
 
-  **How to set up your login information for dual accounts:**
-
-  -	To connect your accounts so you can log in once to access both, set the same password for both accounts.
+  -	**How to set up your login information for dual accounts:** To connect your accounts so you only have to log in once to access both, set the same password for each account.
 
   -	To separate your account logins, set a different password for each account.
   </div>
@@ -139,9 +126,7 @@ You can access your account information and perform certain transactions, such a
 
   For security reasons, the Internet Protocol (IP) address assigned to your computer or device must remain the same during your My Account session. You might see a browser-to-server authentication error and get disconnected from your My Account session **if you’re accessing your account from a mobile device** that changes data networks in the background. In this case, you need to log in again and start a new session.
 
-  Some network managers use security protocols to change IP addresses randomly for different online transactions, which can also generate a browser-to-server authentication error. If you’re accessing your account from a workstation connected to this type of network, your My Account session may end suddenly, and you may receive a message that your IP address changed.
-
-  To assist participants that use **workstations connected to a .gov or .mil network** with multiple security protocols, the Network Security Administrator for that Agency or Service should email the [TSP Webmaster](mailto:webmaster@tsp.gov?subject=TSP.gov%20IP%20Exception%20Request) for an &#8220;IP Address Exception.&#8221;
+  Some network managers use security protocols to change IP addresses randomly for different online transactions, which can also generate a browser-to-server authentication error. If you’re accessing your account from a workstation connected to this type of network, your My Account session may end suddenly, and you may receive a message that your IP address changed. To assist participants that use **workstations connected to a .gov or .mil network** with multiple security protocols, the Network Security Administrator for that Agency or Service should email the [TSP Webmaster](mailto:webmaster@tsp.gov?subject=TSP.gov%20IP%20Exception%20Request) for an “IP Address Exception.”
   </div>
 </li>
 </ul>


### PR DESCRIPTION
- Reverted (manually) to prior version.
- Updated file name and navigation.yml to reflect the preferred page title, "Troubleshoot account access".