### PR TITLE
OI review: Paycheck estimator (part I)

### DIFF
--- a/_includes/calculator/contribution-comparison-calculator/index.js
+++ b/_includes/calculator/contribution-comparison-calculator/index.js
@@ -13,27 +13,24 @@ function initValues(def) {
 
 function setValues(flag) {
   if (flag == 1) {
-    processPanel(1,0,2,0);
-    $('#cccYearsUntilRetirement').val(23);
-    $('#cccYearsInRetirement').val(34);
-    $('#cccSalary').val(57693);
-    $('#cccInterestRate').val(2.74698);
-    $('#cccContributions').val(15.0);
-    $('#cccTaxRateNow').val(32.56987);
-    $('#cccTaxRateLater').val(12.34568);
-    $('#paySchedule').val('Monthly');
-    processPanel(2,0,3,0);
+    setValues(3);
+    showPanel(1);
   }
   if (flag == 2) {
     processPanel(1,0,2,0);
+  }
+  if (flag == 3) {
+    setValues(2);
     $('#cccYearsUntilRetirement').val(23);
+    $('#age50Yes').click();
     $('#cccYearsInRetirement').val(34);
     $('#cccSalary').val(100000);
     $('#cccInterestRate').val(2.74698);
-    $('#cccContributions').val(40.0);
+    $('#cccContributions').val(20.0);
     $('#cccTaxRateNow').val(32.56987);
     $('#cccTaxRateLater').val(12.34568);
     $('#paySchedule').val('Monthly');
+    $('#cccEqualContribution').click();
     processPanel(2,0,3,0);
   }
 }

--- a/_includes/calculator/contribution-comparison-calculator/panel-2.js
+++ b/_includes/calculator/contribution-comparison-calculator/panel-2.js
@@ -142,7 +142,7 @@ function checkContributionAmount(submit) {
     if (age50) { msg += " and catch-up contribution limits "; } else { msg += " limit "; }
     msg += " (" + CurrencyFormatted(IRC_contribution_limit, 'cent');
     if (age50) { msg += " + " + CurrencyFormatted(IRC_catchup_contribution_limit, 'cent'); }
-    msg += " in " + IRC_acting_year + ").";
+    msg += " in " + IRC_limit_year + ").";
     showError('cccContributions', msg);
     // showError('cccSalary', msg);
     return false;

--- a/_includes/calculator/how-much-can-i-contribute/panel-1.js
+++ b/_includes/calculator/how-much-can-i-contribute/panel-1.js
@@ -35,7 +35,7 @@ function reviewYearChange() {
   $('#age50').prop('checked', false);
 }
 function setDropdownDefault() {
-  var defaultYear = constrainYear(determineActingYear());
+  var defaultYear = IRC_acting_year; 
   buildDropdown(defaultYear);
   reviewYearChange();
 }

--- a/_includes/calculator/paycheck-estimator/panel-1.js
+++ b/_includes/calculator/paycheck-estimator/panel-1.js
@@ -11,7 +11,7 @@ panelGood[{{ panelID }}] = function(forceValue) {
 };
 
 panelEnter[{{ panelID }}] = function(panel) {
-  // $('#age50year').html(IRC_current_year);
+  // $('#age50year').html(IRC_limit_year);
   return true;
 }
 panelExit[{{ panelID }}] = function(panel) {

--- a/_includes/calculator/paycheck-estimator/panel-1.js
+++ b/_includes/calculator/paycheck-estimator/panel-1.js
@@ -11,7 +11,7 @@ panelGood[{{ panelID }}] = function(forceValue) {
 };
 
 panelEnter[{{ panelID }}] = function(panel) {
-  // $('#age50year').html(IRC_limit_year);
+  // $('#age50year').html(IRC_current_year);
   return true;
 }
 panelExit[{{ panelID }}] = function(panel) {

--- a/_includes/calculator/paycheck-estimator/panel-3.js
+++ b/_includes/calculator/paycheck-estimator/panel-3.js
@@ -82,6 +82,7 @@ function sumWithholding(op1TradTotal, op2TradTotal) {
   var val1 = val - op1TradTotal;
   var val2 = val - op2TradTotal;
   var monthTax1 = annualTax(val1 * maxpay_freq - fedAllowances * withholding_allowance_rate, taxtableS);
+console.log(val1 * maxpay_freq - fedAllowances * withholding_allowance_rate, {fedAllowances}, {withholding_allowance_rate}, $('#taxStatus').val());
   if ($('#taxStatus').val() == "M") { monthTax1 = annualTax(val1 * maxpay_freq, taxtableM); }
   monthTax1 = parseFloat((monthTax1 / maxpay_freq).toFixed(2));
   var monthTax2 = annualTax(val2 * maxpay_freq - fedAllowances * withholding_allowance_rate, taxtableS);
@@ -160,8 +161,8 @@ function test_limits(submit, amts, contribs) {
     // 17,000
     var pay_freq = get_pay_freq(getPaySchedule());
 
-    var limitRegular = IRC_current_contribution_limit;
-    var limitCatch = IRC_current_catchup_contribution_limit;
+    var limitRegular = IRC_contribution_limit;
+    var limitCatch = IRC_catchup_contribution_limit;
     var limitTotal = limitRegular;
     var age50 = getAge50();
     if (age50 == 'age50Yes') { limitTotal += limitCatch; }
@@ -177,7 +178,7 @@ function test_limits(submit, amts, contribs) {
     } else {
       msg += "limit " + " (" + CurrencyFormatted(limitRegular, 'no_cent');
     }
-    msg += " in " + IRC_current_year + ").";
+    msg += " in " + IRC_limit_year + ").";
     var op1annualTR = pay_freq * contribs[0];  // option 1 annual Trad + Roth
     var op2annualTR = pay_freq * contribs[1];  // option 1 annual Trad + Roth
     $('#totalTR1').html(CurrencyFormatted(op1annualTR, 'no_cent'));

--- a/_includes/calculator/paycheck-estimator/panel-3.js
+++ b/_includes/calculator/paycheck-estimator/panel-3.js
@@ -81,12 +81,15 @@ function sumWithholding(op1TradTotal, op2TradTotal) {
   var val = grossPay - addHold - beforeHold;
   var val1 = val - op1TradTotal;
   var val2 = val - op2TradTotal;
-  var monthTax1 = annualTax(val1 * maxpay_freq - fedAllowances * withholding_allowance_rate, taxtableS);
-console.log(val1 * maxpay_freq - fedAllowances * withholding_allowance_rate, {fedAllowances}, {withholding_allowance_rate}, $('#taxStatus').val());
-  if ($('#taxStatus').val() == "M") { monthTax1 = annualTax(val1 * maxpay_freq, taxtableM); }
+  var taxable1 = val1 * maxpay_freq - fedAllowances * withholding_allowance_rate;
+  var taxable2 = val2 * maxpay_freq - fedAllowances * withholding_allowance_rate;
+  var taxStatus = getTaxStatus();
+  var monthTax1 = annualTax(taxable1, taxtableS);
+  //console.log({taxable1}, {fedAllowances}, {withholding_allowance_rate}, $('#taxStatus').val());
+  if (taxStatus == "M") { monthTax1 = annualTax(taxable1, taxtableM); }
   monthTax1 = parseFloat((monthTax1 / maxpay_freq).toFixed(2));
-  var monthTax2 = annualTax(val2 * maxpay_freq - fedAllowances * withholding_allowance_rate, taxtableS);
-  if ($('#taxStatus').val() == "M") { monthTax2 = annualTax(val2 * maxpay_freq, taxtableM); }
+  var monthTax2 = annualTax(taxable2, taxtableS);
+  if (taxStatus == "M") { monthTax2 = annualTax(taxable2, taxtableM); }
   monthTax2 = parseFloat((monthTax2 / maxpay_freq).toFixed(2));
 
   val = parseFloat((val - afterHold).toFixed(2));

--- a/_includes/calculator/paycheck-estimator/panel-3.js
+++ b/_includes/calculator/paycheck-estimator/panel-3.js
@@ -160,8 +160,8 @@ function test_limits(submit, amts, contribs) {
     // 17,000
     var pay_freq = get_pay_freq(getPaySchedule());
 
-    var limitRegular = IRC_contribution_limit;
-    var limitCatch = IRC_catchup_contribution_limit;
+    var limitRegular = IRC_current_contribution_limit;
+    var limitCatch = IRC_current_catchup_contribution_limit;
     var limitTotal = limitRegular;
     var age50 = getAge50();
     if (age50 == 'age50Yes') { limitTotal += limitCatch; }
@@ -177,7 +177,7 @@ function test_limits(submit, amts, contribs) {
     } else {
       msg += "limit " + " (" + CurrencyFormatted(limitRegular, 'no_cent');
     }
-    msg += " in " + IRC_limit_year + ").";
+    msg += " in " + IRC_current_year + ").";
     var op1annualTR = pay_freq * contribs[0];  // option 1 annual Trad + Roth
     var op2annualTR = pay_freq * contribs[1];  // option 1 annual Trad + Roth
     $('#totalTR1').html(CurrencyFormatted(op1annualTR, 'no_cent'));

--- a/_includes/calculator/paycheck-estimator/panel-4.js
+++ b/_includes/calculator/paycheck-estimator/panel-4.js
@@ -509,10 +509,10 @@ function makeChart(chartMax, year) {
             },
             series: [{
                 // name: '<b>Contribution Type</b>', stack: stack1, color: 'white', data: [0] }, {
-                name: 'Roth Growth', stack: stack1, color:  colorGrowthRoth,
+                name: 'Roth growth', stack: stack1, color:  colorGrowthRoth,
                         data: [parseFloat(roth1Growth[year])-parseFloat(roth1Contribution[year])]
             }, {
-                name: 'Roth Growth', stack: stack2, color:  colorGrowthRoth, showInLegend: false,
+                name: 'Roth growth', stack: stack2, color:  colorGrowthRoth, showInLegend: false,
                         data: [parseFloat(roth2Growth[year])-parseFloat(roth2Contribution[year])]
             }, {
                 name: 'Roth**', stack: stack1, color: colorRoth,
@@ -521,10 +521,10 @@ function makeChart(chartMax, year) {
                 name: 'Roth**', stack: stack2, color: colorRoth, showInLegend: false,
                         data: [parseFloat(roth2Contribution[year])]
             }, {
-                name: 'Traditional Growth', stack: stack1, color: colorGrowthTrad,
+                name: 'Traditional growth', stack: stack1, color: colorGrowthTrad,
                         data: [parseFloat(trad1Growth[year])-parseFloat(trad1Contribution[year])]
             }, {
-                name: 'Traditional Growth', stack: stack2, color: colorGrowthTrad, showInLegend: false,
+                name: 'Traditional growth', stack: stack2, color: colorGrowthTrad, showInLegend: false,
                         data: [parseFloat(trad2Growth[year])-parseFloat(trad2Contribution[year])]
             }, {
                 name: 'Traditional**', stack: stack1, color: colorTrad,
@@ -533,7 +533,7 @@ function makeChart(chartMax, year) {
                 name: 'Traditional**', stack: stack2, color: colorTrad, showInLegend: false,
                         data: [totalTrad2]
             }, {
-                name: $('#orgText1').html(), stack: stack1, color: colorAgency, showInLegend: showMatchInLegend,
+                name: $('#orgText1').html()+' contributions', stack: stack1, color: colorAgency, showInLegend: showMatchInLegend,
                         data: [EMPauto + EMPmatch1]
             }, {
                 name: $('#orgText2').html(), stack: stack2, color: colorAgency, showInLegend: false,

--- a/_includes/calculator/paycheck-estimator/panel-4.js
+++ b/_includes/calculator/paycheck-estimator/panel-4.js
@@ -110,6 +110,9 @@ function clearArrays() {
 
   totalTrad1 = 0.0;
   totalTrad2 = 0.0;
+  EMPauto = 0.0;
+  EMPmatch1 = 0.0;
+  EMPmatch2 = 0.0;
 }
 function initArrayYear(newColumn, oldColumn) {
   // set starting value for new column (year) in arrays, i.e. copy last years value,
@@ -308,7 +311,6 @@ function calculateResults() {
   // $.each(growthbar12.series[0].data, function(i, point){ console.log(point); point.series.legendItem.element.onmouseover = null; });
 
   // $('#option12year').val(39).trigger('change');
-  doZoom();
   showData(0);
   setGraph();
 }
@@ -410,6 +412,8 @@ function makeChart(chartMax, year) {
 
   if (year < 1) { year = 1; }
   if (year > 40) { year = 40; }
+  var showMatchInLegend = false;
+  if (EMPauto > 0.0) { showMatchInLegend = true; }
 
   return  new Highcharts.Chart({
             credits: { enabled: false },
@@ -529,7 +533,7 @@ function makeChart(chartMax, year) {
                 name: 'Traditional**', stack: stack2, color: colorTrad, showInLegend: false,
                         data: [totalTrad2]
             }, {
-                name: $('#orgText1').html(), stack: stack1, color: colorAgency,
+                name: $('#orgText1').html(), stack: stack1, color: colorAgency, showInLegend: showMatchInLegend,
                         data: [EMPauto + EMPmatch1]
             }, {
                 name: $('#orgText2').html(), stack: stack2, color: colorAgency, showInLegend: false,
@@ -586,69 +590,29 @@ function check_labels() {
 
 }
 
-function doZoom() {
-  $('#unzoomedSpan').addClass("hidden");
-  $('#zoomTextImg').addClass("hidden");
-  $('#zoomedSpan').removeClass("hidden");
-
-  if ($('#option12year').val() >= 40) {
-    $('#zoomedSpan').addClass("hidden");
-  }
-}
-function unZoom() {
-  $('#unzoomedSpan').removeClass("hidden");
-  $('#zoomTextImg').removeClass("hidden");
-  $('#zoomedSpan').addClass("hidden");
-}
-
-
-$('#option12zoom').click(function() {
+function drawGraph() {
   var newyear = $('#option12year').val();
   var newMax = goodMax(newyear);
-
-  if ($('#unzoomedSpan').hasClass("hidden")) {
-    unZoom();
-    newMax = goodMax(40);
-  } else {
-    doZoom();
-    newMax = goodMax(newyear);
-  }
-
   growthbar12.destroy();
   growthbar12 = makeChart(newMax, newyear);
   lastMax = newMax;
   $('#option12year').val(newyear);
   check_labels();
-});
+}
 
 $('#option12year').change(function() {
   var newyear = this.value;
   var zone = newyear;
   zone = Math.floor((zone-1)/10) * 10 + 10;
-zone = 40;
-  var newMax = goodMax(zone);
+  zone = 40;
+  // var newMax = goodMax(zone);
+  var newMax = goodMax(newyear);
 
-  // lastMax = newMax;
-  // decide if I need to remake the chart or not
-  if (lastMax != newMax) {
-    growthbar12.destroy();
-    growthbar12 = makeChart(newMax, newyear);
-    lastMax = newMax;
-  } else {
-    growthbar12.series[5].setData([parseFloat(trad1Growth[newyear])-parseFloat(trad1Contribution[newyear])]);
-    growthbar12.series[6].setData([parseFloat(trad2Growth[newyear])-parseFloat(trad2Contribution[newyear])]);
-    growthbar12.series[1].setData([parseFloat(roth1Growth[newyear])-parseFloat(roth1Contribution[newyear])]);
-    growthbar12.series[2].setData([parseFloat(roth2Growth[newyear])-parseFloat(roth2Contribution[newyear])]);
-  }
-  unZoom();
-  // if ($('#option12year').val() >= 40) { doZoom(); }
+  growthbar12.destroy();
+  growthbar12 = makeChart(newMax, newyear);
+  lastMax = newMax;
   check_labels();
 });
-
-// // The next two functions make sure the graph gets initialized correctly, even when the browser is slow
-// window.onload = function() { // this will be run when the whole page is loaded
-//   setTimeout(setGraph, 3000);
-// };
 
 function setGraph() {
    //finish doing things - make sure graph is ready before setting init value

--- a/_includes/calculator/paycheck-estimator/panel-4.js
+++ b/_includes/calculator/paycheck-estimator/panel-4.js
@@ -199,9 +199,11 @@ function calculateResults() {
    var totalDeducted2 = beforeDeduction + afterDeduction + additionalWithholding + monthTax2 + total_contrib2;
    var netPay1 = grossPay - totalDeducted1;
    var netPay2 = grossPay - totalDeducted2;
+   /* moved down below to make global
    var EMPauto = 0.0;
    var EMPmatch1 = 0.0;
    var EMPmatch2 = 0.0;
+   */
    if (rs == 'FERS') {
      EMPauto = grossPay * 0.01;
      EMPmatch1 = FERSmatching(grossPay, match_contrib1);
@@ -356,6 +358,9 @@ colors[3] = colorAgency;
 colors[4] = colorRoth;
 colors[5] = colorTrad;
 
+var EMPauto = 0.0;
+var EMPmatch1 = 0.0;
+var EMPmatch2 = 0.0;
 var trad1Contributionplot = [];
 var trad1Growthplot = [];
 var roth1Contributionplot = [];
@@ -455,6 +460,7 @@ function makeChart(chartMax, year) {
                 symbolPadding: 3,
                 // title: { text: 'Contribution type', style: { fontStyle: 'italic' } },
                 title: { text: 'Contribution type', style: { fontStyle: 'bold' } },
+                reversed: true,
                 shadow: false
             },
             tooltip: {
@@ -522,6 +528,12 @@ function makeChart(chartMax, year) {
             }, {
                 name: 'Traditional**', stack: stack2, color: colorTrad, showInLegend: false,
                         data: [totalTrad2]
+            }, {
+                name: $('#orgText1').html(), stack: stack1, color: colorAgency,
+                        data: [EMPauto + EMPmatch1]
+            }, {
+                name: $('#orgText2').html(), stack: stack2, color: colorAgency, showInLegend: false,
+                        data: [EMPauto + EMPmatch2]
             }
 /*            , {
               dataLabels: { verticalAlign: 'top', x: 0, y: 3, crop: false, color: '#666666', style: { fontWeight: 'bold', fontSize: '11pt' } },

--- a/_includes/calculator/paycheck-estimator/panel-4.js
+++ b/_includes/calculator/paycheck-estimator/panel-4.js
@@ -460,7 +460,7 @@ function makeChart(chartMax, year) {
                 symbolPadding: 3,
                 // title: { text: 'Contribution type', style: { fontStyle: 'italic' } },
                 title: { text: 'Contribution type', style: { fontStyle: 'bold' } },
-                reversed: true,
+                // reversed: true,
                 shadow: false
             },
             tooltip: {

--- a/_includes/calculator/paycheck-estimator/panel-4.md
+++ b/_includes/calculator/paycheck-estimator/panel-4.md
@@ -68,7 +68,7 @@ Results panel (4) for paycheck esitomator.
 <ul class="usa-accordion icons">
 <!-- PROJECTED GROWTH -->
 {% include calculator/accordion-start.html expanded=true divID='projected-growth'
-    icon='far fa-chart-line' title='Projected growth of your account' inList=true %}
+    icon='far fa-chart-line' title='Projected growth of a single contribution' inList=true %}
   <div id="resultSelectorDiv"><p>The results below show how much your account will grow over time based on an expected annual rate of return of <span id="annual-rate">--</span>.</p>
 <fieldset class="usa-fieldset-inputs projected-growth">
 <legend class="">Show growth as:</legend>

--- a/_includes/calculator/paycheck-estimator/panel-4.md
+++ b/_includes/calculator/paycheck-estimator/panel-4.md
@@ -100,10 +100,6 @@ Results panel (4) for paycheck esitomator.
 {% endfor %}
   </select>
   years
-  <span id="option12zoom">
-    <a id="unzoomedSpan" class="zoom-link">Zoom Graph </a><i id="zoomTextImg" class="fal fa-search" ></i>
-    <span id="zoomedSpan" class="zoomed hidden">Zoomed</span>
-  </span>
 </div>
 <!-- DONALD:  This is the end of the zoom feature -->
   <div id="chartResult"></div>

--- a/assets/js/calculator/javascriptTaxTable.js
+++ b/assets/js/calculator/javascriptTaxTable.js
@@ -68,6 +68,9 @@ if (acting_year == 2018) {
 }
 
 // default tax values
+var IRC_current_year = constrainYear(new Date().getFullYear());
+var IRC_current_contribution_limit = taxValues[IRC_current_year]['contribution_limit'];
+var IRC_current_catchup_contribution_limit = taxValues[IRC_current_year]['catchup_limit'];
 var IRC_limit_year = acting_year;
 var IRC_acting_year = acting_year;
 var IRC_contribution_limit = taxValues[acting_year]['contribution_limit'];

--- a/assets/js/calculator/javascriptTaxTable.js
+++ b/assets/js/calculator/javascriptTaxTable.js
@@ -71,7 +71,7 @@ var IRC_contribution_limit = taxValues[IRC_limit_year]['contribution_limit'];
 var IRC_catchup_contribution_limit = taxValues[IRC_limit_year]['catchup_limit'];
 var withholding_allowance_rate = taxValues[IRC_limit_year]['withholding_allowance'];
 var annual_addition = taxValues[IRC_limit_year]['annual_addition'];
-console.log({IRC_limit_year}, {IRC_acting_year}, {IRC_contribution_limit}, {IRC_catchup_contribution_limit}, {withholding_allowance_rate});
+//console.log({IRC_limit_year}, {IRC_acting_year}, {IRC_contribution_limit}, {IRC_catchup_contribution_limit}, {withholding_allowance_rate});
 
 function constrainYear(year) {
   if (year < taxMinYear) { year = taxMinYear; }

--- a/assets/js/calculator/javascriptTaxTable.js
+++ b/assets/js/calculator/javascriptTaxTable.js
@@ -5,7 +5,8 @@ function round_cents(num) {
 
 var taxMinYear = 2018;
 var taxMaxYear = 2021;
-var IRC_acting_year = taxMaxYear;
+
+var IRC_limit_year = constrainYear(new Date().getFullYear());
 
 var taxValues = {
     2021: { contribution_limit: 19500.00, catchup_limit: 6500.00,
@@ -18,9 +19,6 @@ var taxValues = {
       withholding_allowance: 4150.00, annual_addition: 56000 }
 }
 
-var acting_year = constrainYear(determineActingYear());
-// console.log('acting year is ' + acting_year);
-
 // assume most recent tax table
 // IRS Pub. 15-T, Page 6, LEFT, Single.  2021 Percentage Method Tables for Automated Payroll Systems
 var taxtableS = [ [3950.00, 0.00, 0.0], [13900.00, 0.10, 0.0], [44475.00, 0.12, 995.00],
@@ -31,7 +29,7 @@ var taxtableM = [ [12200.00, 0.00, 0.0], [32100.00, 0.10, 0.0], [93250.00, 0.12,
                 [184950.00, 0.22, 9328.0], [342050.00, 0.24, 29502.0], [431050.00, 0.32, 67206.0],
                 [640500.0, 0.35, 95686.0], [-1, 0.37, 168993.5] ];
 
-if (acting_year == 2020) {
+if (IRC_limit_year == 2020) {
   // 2020 tax values
   // IRS Pub. 15-T, Page 6, LEFT, Single.  2020 Percentage Method Tables for Automated Payroll Systems
   taxtableS = [ [3800.00, 0.00, 0.0], [13500.00, 0.10, 0.0], [43275.00, 0.12, 970.0],
@@ -43,7 +41,7 @@ if (acting_year == 2020) {
                 [624150.0, 0.35, 93257.0], [-1, 0.37, 164709.50] ];
 }
 
-if (acting_year == 2019) {
+if (IRC_limit_year == 2019) {
   // 2019 tax values
   // IRS Pub. 15, Table 7(a) SINGLE person, ANNUAL Payroll Period
   taxtableS = [ [3800.00, 0.00, 0.0], [13500.00, 0.10, 0.0], [43275.00, 0.12, 970.0],
@@ -55,7 +53,7 @@ if (acting_year == 2019) {
                 [624150.0, 0.35, 93257.0], [-1, 0.37, 164709.50] ];
 }
 
-if (acting_year == 2018) {
+if (IRC_limit_year == 2018) {
   // 2018 tax table
   // IRS Pub. 15, Table 7(a) SINGLE person, ANNUAL Payroll Period
   taxtableS = [ [3700.00, 0.00, 0.0], [13225.00, 0.10, 0.0], [42400.00, 0.12, 952.5],
@@ -68,16 +66,12 @@ if (acting_year == 2018) {
 }
 
 // default tax values
-var IRC_current_year = constrainYear(new Date().getFullYear());
-var IRC_current_contribution_limit = taxValues[IRC_current_year]['contribution_limit'];
-var IRC_current_catchup_contribution_limit = taxValues[IRC_current_year]['catchup_limit'];
-var IRC_limit_year = acting_year;
-var IRC_acting_year = acting_year;
-var IRC_contribution_limit = taxValues[acting_year]['contribution_limit'];
-var IRC_catchup_contribution_limit = taxValues[acting_year]['catchup_limit'];
-var withholding_allowance_rate = taxValues[acting_year]['withholding_allowance'];
-var annual_addition = taxValues[acting_year]['annual_addition'];
-// console.log(IRC_limit_year, IRC_acting_year, IRC_contribution_limit, IRC_catchup_contribution_limit, withholding_allowance_rate);
+var IRC_acting_year = constrainYear(determineActingYear());
+var IRC_contribution_limit = taxValues[IRC_limit_year]['contribution_limit'];
+var IRC_catchup_contribution_limit = taxValues[IRC_limit_year]['catchup_limit'];
+var withholding_allowance_rate = taxValues[IRC_limit_year]['withholding_allowance'];
+var annual_addition = taxValues[IRC_limit_year]['annual_addition'];
+console.log({IRC_limit_year}, {IRC_acting_year}, {IRC_contribution_limit}, {IRC_catchup_contribution_limit}, {withholding_allowance_rate});
 
 function constrainYear(year) {
   if (year < taxMinYear) { year = taxMinYear; }


### PR DESCRIPTION
SAVINGS GROWTH, PAYCHECK ESTIMATOR, CCC
- Updated code for all calculators EXCEPT "How much can I contribute?" to use 2021 IRC limits.
- Updated error message to reference the current year, 2021. *"Your regular employee contributions exceed the Internal Revenue Code (IRC) elective deferral and catch-up contribution limits ($19,500 + $6,500 in 2020)."*

PAYCHECK ESTIMATOR
- Changed accordion button to “Projected growth of a single contribution” PE
- Removed "Zoom graph" feature PE
- Chart redraws each time a new growth year is selected; column fills entire height of chart
- Changed left-to-right order of legend labels: Roth Growth, Roth, Traditional Growth, Traditional, Agency/Service contributions