### PR TITLE
Fixed link to Share price history on L Fund pages; Fees & more info.

### DIFF
--- a/_funds/L-2025.md
+++ b/_funds/L-2025.md
@@ -42,7 +42,7 @@ summary_details:
 additional_info: |
   The L 2025 Fund is designed for you if your time horizons falls within the 2021 through 2027 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2025 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: low-medium

--- a/_funds/L-2030.md
+++ b/_funds/L-2030.md
@@ -44,7 +44,7 @@ top_ten_holdings:
 additional_info: |
   The L 2030 Fund is designed for you if your time horizon falls within the 2028 through 2032 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2030 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: medium

--- a/_funds/L-2035.md
+++ b/_funds/L-2035.md
@@ -46,7 +46,7 @@ top_ten_holdings:
 additional_info: |
   The L 2035 Fund is designed for you if your time horizon falls within the 2033 through 2037 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2035 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: medium

--- a/_funds/L-2040.md
+++ b/_funds/L-2040.md
@@ -44,7 +44,7 @@ top_ten_holdings:
 additional_info: |
   The L 2040 Fund is designed for you if your time horizon falls within the 2038 through 2042 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2040 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: medium-high

--- a/_funds/L-2045.md
+++ b/_funds/L-2045.md
@@ -46,7 +46,7 @@ top_ten_holdings:
 additional_info: |
   The L 2045 Fund is designed for you if your time horizon falls within the 2043 through 2047 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2045 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: medium-high

--- a/_funds/L-2050.md
+++ b/_funds/L-2050.md
@@ -44,7 +44,7 @@ top_ten_holdings:
 additional_info: |
   The L 2050 Fund is designed for you if your time horizon falls within the 2048 through 2052 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2050 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: high

--- a/_funds/L-2055.md
+++ b/_funds/L-2055.md
@@ -46,7 +46,7 @@ top_ten_holdings:
 additional_info: |
   The L 2055 Fund is designed for you if your time horizon falls within the 2053 through 2057 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2055 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: high

--- a/_funds/L-2060.md
+++ b/_funds/L-2060.md
@@ -46,7 +46,7 @@ top_ten_holdings:
 additional_info: |
   The L 2060 Fund is designed for you if your time horizon falls within the 2058 through 2062 range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2060 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: high

--- a/_funds/L-2065.md
+++ b/_funds/L-2065.md
@@ -46,7 +46,7 @@ top_ten_holdings:
 additional_info: |
   The L 2065 Fund is designed for you if your time horizon falls within the 2062 or later range. The asset allocation of this fund is adjusted quarterly, moving to a more conservative mix, gradually approaching that of the L Income Fund. Between quarterly adjustments, the asset allocation of the L 2065 Fund is maintained through daily rebalancing to the fund’s target allocation.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: high

--- a/_funds/L-income.md
+++ b/_funds/L-income.md
@@ -42,7 +42,7 @@ top_ten_holdings:
 additional_info: |
   The L Income Fund is designed to produce current income if you are already receiving money from your TSP account through monthly payments or if you plan to withdraw or to begin withdrawing from your account next year. The asset allocations are based on the investment consultant’s assumptions regarding future investment returns, inflation, economic growth, and interest rates. We review these assumptions at least annually to determine whether changes to the allocations are warranted.
 
-  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit [Share Price History]({{ site.baseurl }}/fund-performance/share-price-history/). Past performance does not guarantee future results.
+  Remember, however, that expected risk and return are based on assumptions about future economic conditions and investment performance. There is no guaranteed rate of return for any period, either short-term or long-term. For the fund’s historical returns, visit <a href="/fund-performance/share-price-history/">Share price history</a>. Past performance does not guarantee future results.
 risks: |
   When you invest in the L Funds, you are subject to the investment risks associated with the G, F, C, S, and I funds. Your account is not guaranteed against loss. The L Funds can have periods of gain and loss, just as the individual TSP funds do.
 risk_level: low


### PR DESCRIPTION
- During review of df-726-annual-updates-2020 I noticed the link to Share Price History under "Fees & more info" on all L Fund pages was broken.
- Updated links were verified for accuracy on localhost.
