### PR TITLE
Updated C Fund gross_expense as per M. Jerue on 2/22/2021

### DIFF
--- a/_funds-retired/L-2010.md
+++ b/_funds-retired/L-2010.md
@@ -27,6 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
+inception_date: 8/1/2005
 summary_update: 12/31/2019
 summary_details:
     assets: $136.5 billion

--- a/_funds/C.md
+++ b/_funds/C.md
@@ -31,7 +31,7 @@ summary_update: 12/31/2020
 summary_details:
     assets: $251.5 billion
     as_of_year: 2020
-    gross_expense:  .052
+    gross_expense:  .059
     net_expense:    .049
     investment_expense:  .002
     benchmark_index: S&P 500 Index  | spglobal.com

--- a/_includes/components/fund-comparison.html
+++ b/_includes/components/fund-comparison.html
@@ -154,7 +154,10 @@
           </th>
       {% for fund in sorted %}
         <td class="fund-content hide col{{ forloop.index }}">
-          <p class="numeric">{% include components/expense_string.html value=fund.summary_details.investment_expense percentOnly=true %}</p>
+          {% assign total_expense = fund.summary_details.net_expense | plus: fund.summary_details.investment_expense %}
+          {% if fund.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
+          {% include components/expense_string.html value=total_expense percentOnly=true %}
+          <p class="numeric">{% include components/expense_string.html value=total_expense percentOnly=true %}</p>
         </td>
       {% endfor %}
       </tr>

--- a/_includes/components/fund-comparison.html
+++ b/_includes/components/fund-comparison.html
@@ -147,16 +147,15 @@
         </td>
       {% endfor %}
       </tr>
-      <!-- Expense -->
+      <!-- Total expense ratio -->
       <tr>
         <th scope="row">
-          Expense
+          <span class="expense-ratio">Total expense ratio</span>
           </th>
       {% for fund in sorted %}
         <td class="fund-content hide col{{ forloop.index }}">
           {% assign total_expense = fund.summary_details.net_expense | plus: fund.summary_details.investment_expense %}
           {% if fund.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
-          {% include components/expense_string.html value=total_expense percentOnly=true %}
           <p class="numeric">{% include components/expense_string.html value=total_expense percentOnly=true %}</p>
         </td>
       {% endfor %}

--- a/_sass/components/_fund-comparison-tool.scss
+++ b/_sass/components/_fund-comparison-tool.scss
@@ -28,6 +28,12 @@
   }
   tbody th {
     border-left: none;
+
+    span.expense-ratio { // Limit width of "Total expense ratio" table row header.
+      display: inline-block;
+      max-width: 8ch;
+      font-size: inherit;
+    }
   }
   tbody tr {
     &:last-child {


### PR DESCRIPTION
- On “Administrative and investment expenses” the gross administrative expense ratio for the C Fund should be 0.059%, not 0.052%.
- Comparison tables on the Individual and Lifecycle Fund index pages are showing the **investment expense ratio**.  It should be displaying the **total investment ratio**. 