### PR TITLE
Dav 738 add tab parameters to url

### DIFF
--- a/_includes/bottom-scripts.html
+++ b/_includes/bottom-scripts.html
@@ -27,11 +27,14 @@ Autoloads calculator panel js files.
   {% include {{ indexJS }}  maxPanels=maxPanels %}
 {% endif %}
 
-{% if page.document-ready %}
+{% if page.document-ready or layout.document-ready %}
 <script type="text/javascript">
 <!--
 $(document).ready(function() {
   {% for item in page.document-ready %}
+    {{ item }}
+  {% endfor %}
+  {% for item in layout.document-ready %}
     {{ item }}
   {% endfor %}
 });

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,7 @@
 </head>
 
 <body class="{{ layout.class }} {{ page.class }}">
+  <input type="hidden" id="pageTitle" value="{{page.title}}">
   <!-- Google Tag Manager (noscript) -->
   <!-- <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MLDLTMR" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> -->
   <!-- End Google Tag Manager (noscript) -->

--- a/_layouts/fund-details.html
+++ b/_layouts/fund-details.html
@@ -72,7 +72,7 @@ document-ready:
   </div>
 </div>
 
-<div id="performance" class="performance">
+<div id="performance-and-risks" class="performance">
 <h2>Performance</h2>
 <span id="no_data_yet_message"></span>
 <table class="usa-table-borderless avg-annual-returns">

--- a/_layouts/fund-details.html
+++ b/_layouts/fund-details.html
@@ -72,7 +72,7 @@ document-ready:
   </div>
 </div>
 
-<div id="performance-and-risks" class="performance">
+<div id="performance" class="performance">
 <h2>Performance</h2>
 <span id="no_data_yet_message"></span>
 <table class="usa-table-borderless avg-annual-returns">
@@ -155,7 +155,7 @@ document-ready:
       </div>
     </li>
     <li>
-      <button id="performance"  onClick="fundTabClicked(this, '{{site.title}}');"
+      <button id="performance-and-risks"  onClick="fundTabClicked(this, '{{site.title}}');"
           class="usa-accordion-button" aria-expanded="false" aria-controls="a2">Performance &amp; risks</button>
       <div id="a2" class="usa-accordion-content">
         <div class="usa-grid-full">

--- a/_layouts/fund-details.html
+++ b/_layouts/fund-details.html
@@ -8,7 +8,11 @@ scripts:
   - /assets/js/highcharts/exporting.js
   - /assets/js/highcharts/export-data.js
   - /assets/js/highcharts/data.js
+  - /assets/js/calculator/calculator.js
   - /assets/js/calculator/lifecycle.js
+  - /assets/js/fund-details.js
+document-ready:
+  - initFundTab();
 ---
 {% assign sidenav = site.data.navigation[page.sidenav] | default: page.sidenav %}
 {% if sidenav %}
@@ -98,111 +102,107 @@ scripts:
 <section id="fund-tabs">
 <ul class="usa-accordion usa-tabs">
     <li>
-        <button class="usa-accordion-button" aria-expanded="true" aria-controls="a1">
-          Summary
-    </button>
-        <div id="a1" class="usa-accordion-content">
-          <div class="usa-grid-full">
-            <div class="usa-width-one-half fund-summary-details">
-              <h3 id="details">Details {% if page.summary_update %}<span class="as-of-date">As of {{ page.summary_update }}</span>{% endif %}</h3>
-                <p><b>Assets</b><br>
-                {{ page.summary_details.assets }}
-              </p>
-              <p><b>Total expense ratio</b><br>
-                {% assign total_expense = page.summary_details.net_expense | plus: page.summary_details.investment_expense %}
-                {% if page.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
-                {% include components/expense_string.html value=total_expense as_of=page.summary_details.as_of_year %}
-              </p>
-{% if page.Fund_type == 'Individual' %}
-                <p><b>Benchmark index</b><br>
-                  {{ page.summary_details.benchmark_index }}
-                </p>
-                <p><b>Asset manager</b><br>
-                {{ page.summary_details.asset_manager }}
-              </p>
-{% endif %}
-              <p><b>Inception date</b><br>
-              {{ page.inception_date }}
+      <button id='summary' onClick="fundTabClicked(this, '{{site.title}}');"
+           class="usa-accordion-button" aria-expanded="true" aria-controls="a1">Summary</button>
+      <div id="a1" class="usa-accordion-content">
+        <div class="usa-grid-full">
+          <div class="usa-width-one-half fund-summary-details">
+            <h3 id="details">Details {% if page.summary_update %}<span class="as-of-date">As of {{ page.summary_update }}</span>{% endif %}</h3>
+              <p><b>Assets</b><br>
+              {{ page.summary_details.assets }}
             </p>
-            </div>
-            <div class="usa-width-one-half fund-summary-top-ten">
-{% if page.Fund_type == 'L' or page.Fund_type == 'Retired' %}
-              <h3>Allocation target</h3>
-              <div id="pie-lfund" class="hc-summary-pie-box">
-                <img src="/assets/img/icons/pie-chart.svg" />
-              </div>
-              <div id="pie-tooltip" class="l-fund-summary-tooltip"></div>
-{% else %}
-              <h3>Top ten holdings {% if page.top_ten_update %}<span class="as-of-date">As of {{ page.top_ten_update }}</span>{% endif %}</h3>
-              {% if page.top_ten_text %}
-              {{ page.top_ten_text | markdownify }}
-              {% else %}
-              <ol>
-              {% for item in page.top_ten_holdings %}
-              <li>
-                  <span class="holdings-abbr">{{ item.abbr }}</span>
-                  {{ item.name }}
-              </li>
-              {% endfor %}
-            </ol>
-            {% endif %}
+            <p><b>Total expense ratio</b><br>
+              {% assign total_expense = page.summary_details.net_expense | plus: page.summary_details.investment_expense %}
+              {% if page.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
+              {% include components/expense_string.html value=total_expense as_of=page.summary_details.as_of_year %}
+            </p>
+{% if page.Fund_type == 'Individual' %}
+              <p><b>Benchmark index</b><br>
+                {{ page.summary_details.benchmark_index }}
+              </p>
+              <p><b>Asset manager</b><br>
+              {{ page.summary_details.asset_manager }}
+            </p>
 {% endif %}
+            <p><b>Inception date</b><br>
+            {{ page.inception_date }}
+          </p>
+          </div>
+          <div class="usa-width-one-half fund-summary-top-ten">
+{% if page.Fund_type == 'L' or page.Fund_type == 'Retired' %}
+            <h3>Allocation target</h3>
+            <div id="pie-lfund" class="hc-summary-pie-box">
+              <img src="/assets/img/icons/pie-chart.svg" />
             </div>
+            <div id="pie-tooltip" class="l-fund-summary-tooltip"></div>
+{% else %}
+            <h3>Top ten holdings {% if page.top_ten_update %}<span class="as-of-date">As of {{ page.top_ten_update }}</span>{% endif %}</h3>
+            {% if page.top_ten_text %}
+            {{ page.top_ten_text | markdownify }}
+            {% else %}
+            <ol>
+            {% for item in page.top_ten_holdings %}
+            <li>
+                <span class="holdings-abbr">{{ item.abbr }}</span>
+                {{ item.name }}
+            </li>
+            {% endfor %}
+          </ol>
+          {% endif %}
+{% endif %}
           </div>
         </div>
+      </div>
     </li>
     <li>
-        <button class="usa-accordion-button" aria-expanded="false" aria-controls="a2">
-      Performance &amp; risks
-    </button>
-        <div id="a2" class="usa-accordion-content">
-          <div class="usa-grid-full">
-            <div class="usa-width-one-whole">
-              <div id="annualReturnsColumn" class="hc-annual-returns-bar"></div>
-              <div id="annualReturnsTable" class="hc-annual-returns-table"></div>
-              <div id="growthLifetime" class="hc-growth-lifetime"></div>
-            </div>
+      <button id="performance"  onClick="fundTabClicked(this, '{{site.title}}');"
+          class="usa-accordion-button" aria-expanded="false" aria-controls="a2">Performance &amp; risks</button>
+      <div id="a2" class="usa-accordion-content">
+        <div class="usa-grid-full">
+          <div class="usa-width-one-whole">
+            <div id="annualReturnsColumn" class="hc-annual-returns-bar"></div>
+            <div id="annualReturnsTable" class="hc-annual-returns-table"></div>
+            <div id="growthLifetime" class="hc-growth-lifetime"></div>
           </div>
         </div>
+      </div>
     </li>
     <li>
-        <button class="usa-accordion-button" aria-expanded="false" aria-controls="a3">
-      Composition
-    </button>
-        <div id="a3" class="usa-accordion-content">
+      <button id="composition" onClick="fundTabClicked(this, '{{site.title}}');"
+          class="usa-accordion-button" aria-expanded="false" aria-controls="a3">Composition</button>
+      <div id="a3" class="usa-accordion-content">
 {% include components/fund-composition.html %}
-        </div>
+      </div>
     </li>
     <li>
-        <button class="usa-accordion-button" aria-expanded="false" aria-controls="a4">
-      Fees &amp; more info
-    </button>
-        <div id="a4" class="usa-accordion-content">
-          <div class="usa-grid-full">
-            <div class="usa-width-one-half">
-              <h3>Fees {% if page.summary_update %}<span class="as-of-date">As of {{ page.summary_update }}</span>{% endif %}</h3>
-              <p><b>Net administrative expense ratio<sup>1</sup></b><br>
-                {% include components/expense_string.html value=page.summary_details.net_expense as_of=page.summary_details.as_of_year %}
-              </p>
-              <p><b>Investment expense ratio</b><br>
-                {% include components/expense_string.html value=page.summary_details.investment_expense as_of=page.summary_details.as_of_year %}
-              </p>
-              <p><b>Total expense ratio<sup>2</sup></b><br>
-                {% assign total_expense = page.summary_details.net_expense | plus: page.summary_details.investment_expense %}
-                {% if page.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
-                {% include components/expense_string.html value=total_expense as_of=page.summary_details.as_of_year %}
-              </p>
-              <ol class="footnotes">
-                <li>{% include components/expense_string.html value=page.summary_details.net_expense alt_value=page.summary_details.alt_net_expense explain=true %}</li>
-                <li>Fees paid to the investment manager.</li>
-              </ol>
-            </div>
-            <div class="usa-width-one-half">
-              <h3>Additional information </h3>
-              {{ page.additional_info | markdownify }}
-            </div>
+      <button id="fees"  onClick="fundTabClicked(this, '{{site.title}}');"
+           class="usa-accordion-button" aria-expanded="false" aria-controls="a4">Fees &amp; more info</button>
+      <div id="a4" class="usa-accordion-content">
+        <div class="usa-grid-full">
+          <div class="usa-width-one-half">
+            <h3>Fees {% if page.summary_update %}<span class="as-of-date">As of {{ page.summary_update }}</span>{% endif %}</h3>
+            <p><b>Net administrative expense ratio<sup>1</sup></b><br>
+              {% include components/expense_string.html value=page.summary_details.net_expense as_of=page.summary_details.as_of_year %}
+            </p>
+            <p><b>Investment expense ratio</b><br>
+              {% include components/expense_string.html value=page.summary_details.investment_expense as_of=page.summary_details.as_of_year %}
+            </p>
+            <p><b>Total expense ratio<sup>2</sup></b><br>
+              {% assign total_expense = page.summary_details.net_expense | plus: page.summary_details.investment_expense %}
+              {% if page.summary_details.investment_expense == "-" %}{% assign total_expense = "-" %}{% endif %}
+              {% include components/expense_string.html value=total_expense as_of=page.summary_details.as_of_year %}
+            </p>
+            <ol class="footnotes">
+              <li>{% include components/expense_string.html value=page.summary_details.net_expense alt_value=page.summary_details.alt_net_expense explain=true %}</li>
+              <li>Fees paid to the investment manager.</li>
+            </ol>
+          </div>
+          <div class="usa-width-one-half">
+            <h3>Additional information </h3>
+            {{ page.additional_info | markdownify }}
           </div>
         </div>
+      </div>
     </li>
 </ul>
 </section>

--- a/assets/js/ajaxFetch.js
+++ b/assets/js/ajaxFetch.js
@@ -139,12 +139,12 @@ var groupFundAnnualReturns = function(setName) {
             var values = lines[i].split(', ');
             var fundName = mapFundName(values[0]);
             //console.log(i, fundName, lines[i]);
-            $('#ret-YTD-'+fundName).html(values[1]+'%');
-            $('#ret-1YR-'+fundName).html(values[2]+'%');
-            $('#ret-3YR-'+fundName).html(values[3]+'%');
-            $('#ret-5YR-'+fundName).html(values[4]+'%');
+            if (values[1] != '-') { $('#ret-YTD-'+fundName).html(values[1]+'%'); }
+            if (values[2] != '-') { $('#ret-1YR-'+fundName).html(values[2]+'%'); }
+            if (values[3] != '-') { $('#ret-3YR-'+fundName).html(values[3]+'%'); }
+            if (values[4] != '-') { $('#ret-5YR-'+fundName).html(values[4]+'%'); }
             if (values[5] != '-') { $('#ret-10YR-'+fundName).html(values[5]+'%'); }
-            $('#ret-Life-'+fundName).html(values[6]+'%');
+            if (values[6] != '-') { $('#ret-Life-'+fundName).html(values[6]+'%'); }
           }
           //console.log(rc[1], setName);
           if (setName == 'Index') { $('#index-as-of').html(' as of ' + rc[2]); }

--- a/assets/js/copy-to-clipboard.js
+++ b/assets/js/copy-to-clipboard.js
@@ -50,3 +50,8 @@ function outFunc(element) {
 }
 
 // ref: https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_copy_clipboard2
+
+// header--extended share button
+$('#shareModal').on('show.bs.modal', function (e) {
+  $('#fullURL').val(window.location.href);
+});

--- a/assets/js/fund-details.js
+++ b/assets/js/fund-details.js
@@ -1,5 +1,5 @@
 function initFundTab() {
-  var tabs = [ 'summary', 'performance', 'composition', 'fees'];
+  var tabs = [ 'summary', 'performance-and-risks', 'composition', 'fees'];
   var tab = getQueryString('tab');
   if (typeof tab === 'undefined') { tab = 'summary'; }
   if (tabs.includes(tab)) {


### PR DESCRIPTION
Add ability to send links that open an accordion on a Fund page.

- For example, tsp.gov/funds-lifecycle/l-2030/#performance?_fees
The parameter (?_fees) will bring a user to the L 2030 page, scroll to the Performance section of the page, and open the **Fees & more info** tab
- Current functionality only permits scrolling to the Performance section, where the **Summary** tab is always open by default.
- Ref: https://trello.com/c/SNQfLqOZ