### PR TITLE
Named D. Vashee as FRTIB SOAP as per J. Courtney 3/30/2021 9:34am.

### DIFF
--- a/pages/contact-privacy/index.md
+++ b/pages/contact-privacy/index.md
@@ -8,7 +8,7 @@ permalink: /contact-privacy/
 ---
 # How to contact us
 
-The Office of Management and Budget (OMB) requires that each Government agency designate a Senior Agency Official for Privacy (SAOP) who has agency-wide responsibility and accountability for the agency’s privacy program. General Counsel Megan Grumbine serves as FRTIB’s SAOP.
+The Office of Management and Budget (OMB) requires that each Government agency designate a Senior Agency Official for Privacy (SAOP) who has agency-wide responsibility and accountability for the agency’s privacy program. Acting General Counsel Dharmesh Vashee serves as FRTIB’s SAOP.
 
 If you would like to contact FRTIB’s Privacy Office, or if you would like to submit a privacy complaint, please email us at [privacy@tsp.gov](mailto:privacy@tsp.gov).
 


### PR DESCRIPTION
From: Jim Courtney <Jim.Courtney@FRTIB.GOV> 
Sent: Tuesday, March 30, 2021 9:34 AM
To: Lorraine Terry <Lorraine.Terry@FRTIB.GOV>
Subject: RE: page needing update
 
Lorraine,
Please ask Donald or CJ to change the last sentence of that first paragraph to read:
Acting General Counsel Dharmesh Vashee serves as FRTIB’s SAOP.
 
Thanks,
Jim