### PR TITLE
Restore secure-alerts feature to Plan news

### DIFF
--- a/_includes/next-outage.html
+++ b/_includes/next-outage.html
@@ -1,6 +1,0 @@
-<div class="next-outage">
-  <!-- <ul>
-    <li><i class="fas fa-power-off"></i> <strong>Next outage:</strong> 1:30 a.m. (ET) Saturday, August 22,</li>
-    <li>to 1:30 a.m. (ET) on Monday, August 24</li>
-  </ul> -->
-</div>

--- a/_layouts/page-plan-news.html
+++ b/_layouts/page-plan-news.html
@@ -27,9 +27,7 @@ scripts:
 
 {% capture top_of_page %}
 # Plan news
-{:#plan-news}
 
-{% include next-outage.html %}
 {% endcapture %}
 
 <div class="{{xtra_class}} usa-layout-docs-main_content" markdown="1">

--- a/_sass/components/_news-and-resources.scss
+++ b/_sass/components/_news-and-resources.scss
@@ -124,6 +124,7 @@ ul.usa-accordion {
     font-weight: 600;
     text-align: center;
     margin-top: 0.67em;
+    margin-bottom: 6rem;
     line-height: 0;
   }
 

--- a/pages/news-and-resources/index.md
+++ b/pages/news-and-resources/index.md
@@ -15,7 +15,7 @@ document-ready:
   - // getAnnuityRate();
   - getLoanAndAnnuityRate();
 # To test outage messages, change 'today' to a specific date.
-# getSecureAlerts('ID of container div', 'YYYYMMDD')
+# getSecureAlerts('ID of container div', 'YYYYMMDD' or 'today')
   - getSecureAlerts('secure-alerts', 'today');
 redirect_from:
   - /whatsnew/
@@ -23,8 +23,6 @@ redirect_from:
 ---
 
 # News and resources
-
-{% include next-outage.html %}
 
 <div id="secure-alerts"></div>
 

--- a/pages/news-and-resources/plan-news.md
+++ b/pages/news-and-resources/plan-news.md
@@ -6,6 +6,8 @@ styles:
 scripts:
   - /assets/js/ajaxFetch.js
   - /assets/js/forms.js
+# calculator.js required for doc-ready getSecureAlerts
+  - /assets/js/calculator/calculator.js
   - /assets/js/plan-news.js
   - /assets/js/ajax-usa-search-gov.js
 permalink: /news-and-resources/plan-news/
@@ -21,9 +23,6 @@ redirect_from:
 ---
 
 # Plan news
-{:#plan-news}
-
-{% include next-outage.html %}
 
 <div id="secure-alerts"></div>
 


### PR DESCRIPTION
- Plan news was not displaying holiday closing or outage messages as previously programmed.
- The required `calculator.js` script missing from front matter.
- Restored script link.
- Deleted unused HTML from previous solution; updated CSS accordingly.
- Error detected by Web Design Specialist (D. Ferracci).
- Approved for production by D. Ferracci as per Desktop Procedures.

Ref: https://federalist-bb524037-85b7-4932-b166-937acfe82a45.app.cloud.gov/preview/frtib/tsp-redesign/dav-699-outage-message-block/news-and-resources/plan-news/