### PR TITLE
Changed inception date to 7/1/2020 as per M. Jerue on 5/5/2021.

### DIFF
--- a/_funds/L-2025.md
+++ b/_funds/L-2025.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $6.4 billion

--- a/_funds/L-2035.md
+++ b/_funds/L-2035.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $2.1 billion

--- a/_funds/L-2045.md
+++ b/_funds/L-2045.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $1.1 billion

--- a/_funds/L-2055.md
+++ b/_funds/L-2055.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $0.7 billion

--- a/_funds/L-2060.md
+++ b/_funds/L-2060.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $0.4 billion

--- a/_funds/L-2065.md
+++ b/_funds/L-2065.md
@@ -27,7 +27,7 @@ avg_annual_returns:
     five_yr: "-"
     ten_yr: "-"
     lifetime: "-"
-inception_date: 6/30/2020
+inception_date: 7/1/2020
 summary_update: 12/31/2020
 summary_details:
     assets: $1.0 billion


### PR DESCRIPTION
> First, inception date is listed as 6/30/2020 for the new L Funds (L 2025, L 2035, L 2045, L 2055, L 2060, L 2065). **That should be 7/1/2020.** -- *M. Jerue (5/5/2021)*

Ref: https://trello.com/c/dEnAsGXH